### PR TITLE
feat: added settings modal and saving keys/base URL from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ GROQ_API_KEY=XXX
 OPENAI_API_KEY=XXX
 ANTHROPIC_API_KEY=XXX
 ```
+4. You can now optionally configure API keys and other settings directly from the settings UI in the application via the gear icon on the prompt text area.
 
 Optionally, you can set the debug level:
 
@@ -124,6 +125,8 @@ This will start the Remix Vite development server. You will need Google Chrome C
 ## Tips and Tricks
 
 Here are some tips to get the most out of Bolt.new:
+
+- **Settings Management**: You can now manage your API keys, base URLs, and current provider dynamically via the settings UI. This allows for real-time changes without needing to restart the application.
 
 - **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
 

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -35,7 +35,7 @@ const ModelSelector = ({ model, setModel, modelList, currentProvider, onProvider
         onChange={(e) => {
           onProviderChange(e.target.value);
           const firstModel = [...modelList].find(m => m.provider == e.target.value);
-          setModel(firstModel ? firstModel.name : '');
+          if (setModel) setModel(firstModel ? firstModel.name : '');
         }}
         className="w-full p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
       >
@@ -47,7 +47,7 @@ const ModelSelector = ({ model, setModel, modelList, currentProvider, onProvider
       </select>
       <select
         value={model}
-        onChange={(e) => setModel(e.target.value)}
+        onChange={(e) => setModel && setModel(e.target.value)}
         className="w-full p-2 rounded-lg border border-bolt-elements-borderColor bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
       >
         {[...modelList].filter(e => e.provider == currentProvider && e.name).map((modelOption) => (
@@ -74,7 +74,7 @@ interface BaseChatProps {
   promptEnhanced?: boolean;
   input?: string;
   model: string;
-  setModel: (model: string) => void;
+  setModel?: (model: string) => void; // Make setModel optional
   handleStop?: () => void;
   sendMessage?: (event: React.UIEvent, messageInput?: string) => void;
   handleInputChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -112,8 +112,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       const savedProvider = localStorage.getItem('DEFAULT_PROVIDER');
       const savedModel = localStorage.getItem('DEFAULT_MODEL');
       if (savedProvider) setProvider(savedProvider);
-      if (savedModel) setModel(savedModel);
-    }, []);
+      if (savedModel && setModel) setModel(savedModel);
+    }, [setModel]);
 
     return (
       <div
@@ -289,7 +289,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
             const savedProvider = localStorage.getItem('DEFAULT_PROVIDER');
             const savedModel = localStorage.getItem('DEFAULT_MODEL');
             if (savedProvider) setProvider(savedProvider);
-            if (savedModel) setModel(savedModel);
+            if (savedModel && setModel) setModel(savedModel);
           }}
         />
       </div>

--- a/app/components/chat/SettingsModal.tsx
+++ b/app/components/chat/SettingsModal.tsx
@@ -1,0 +1,245 @@
+import { DialogRoot, Dialog, DialogTitle, DialogButton } from '~/components/ui/Dialog';
+import { useState, useEffect } from 'react';
+import { classNames } from '~/utils/classNames';
+import { initializeModelList } from '~/utils/constants';
+
+interface SettingsProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSettingsUpdate?: () => void;
+}
+
+interface ApiKeys {
+  [key: string]: string;
+}
+
+const API_PROVIDERS = {
+  'OpenAI': 'OPENAI_API_KEY',
+  'Anthropic': 'ANTHROPIC_API_KEY',
+  'Groq': 'GROQ_API_KEY',
+  'OpenRouter': 'OPEN_ROUTER_API_KEY',
+  'Google': 'GOOGLE_GENERATIVE_AI_API_KEY',
+  'DeepSeek': 'DEEPSEEK_API_KEY',
+  'Mistral': 'MISTRAL_API_KEY',
+  'Ollama': 'OLLAMA_API_BASE_URL',
+  'OpenAILike': 'OPENAI_LIKE_API_KEY',
+} as const;
+
+export function Settings({ open, onOpenChange, onSettingsUpdate }: SettingsProps) {
+  const [isApiKeysOpen, setIsApiKeysOpen] = useState(false);
+  const [apiKeys, setApiKeys] = useState<ApiKeys>({});
+  const [defaultProvider, setDefaultProvider] = useState('');
+  const [defaultModel, setDefaultModel] = useState('');
+  const [ollamaBaseUrl, setOllamaBaseUrl] = useState('');
+  const [openAiLikeBaseUrl, setOpenAiLikeBaseUrl] = useState('');
+
+  // Load settings when component mounts or modal opens
+  useEffect(() => {
+    if (open) {
+      // Load API keys
+      const savedKeys: ApiKeys = {};
+      Object.values(API_PROVIDERS).forEach(key => {
+        const value = localStorage.getItem(key);
+        if (value) savedKeys[key] = value;
+
+        // Load base URLs
+      const ollamaBaseUrlSaved = localStorage.getItem('OLLAMA_API_BASE_URL');
+      if (ollamaBaseUrlSaved) setOllamaBaseUrl(ollamaBaseUrlSaved);
+
+      const openAiLikeBaseUrlSaved = localStorage.getItem('OPENAI_LIKE_API_BASE_URL');
+      if (openAiLikeBaseUrlSaved) setOpenAiLikeBaseUrl(openAiLikeBaseUrlSaved);
+    });
+      setApiKeys(savedKeys);
+
+      // Load default provider/model
+      const savedProvider = localStorage.getItem('DEFAULT_PROVIDER');
+      if (savedProvider) setDefaultProvider(savedProvider);
+
+      const savedModel = localStorage.getItem('DEFAULT_MODEL');
+      if (savedModel) setDefaultModel(savedModel);
+    }
+  }, [open]);
+
+  const handleSave = async () => {
+    // Save API keys
+    Object.entries(apiKeys).forEach(([key, value]) => {
+      if (value) {
+        localStorage.setItem(key, value);
+      } else {
+        localStorage.removeItem(key);
+      }
+    });
+
+    // Save OpenAI-like base URL
+    if (openAiLikeBaseUrl) {
+      localStorage.setItem('OPENAI_LIKE_API_BASE_URL', openAiLikeBaseUrl);
+    } else {
+      localStorage.removeItem('OPENAI_LIKE_API_BASE_URL');
+    }
+
+    // Save Ollama base URL, ensuring it doesn't end with /api
+    if (ollamaBaseUrl) {
+      const cleanBaseUrl = ollamaBaseUrl.endsWith('/api') 
+        ? ollamaBaseUrl.slice(0, -4) 
+        : ollamaBaseUrl;
+      localStorage.setItem('OLLAMA_API_BASE_URL', cleanBaseUrl);
+    } else {
+      localStorage.removeItem('OLLAMA_API_BASE_URL');
+    }
+
+    // Save default provider/model
+    if (defaultProvider) {
+      localStorage.setItem('DEFAULT_PROVIDER', defaultProvider);
+    } else {
+      localStorage.removeItem('DEFAULT_PROVIDER');
+    }
+
+    if (defaultModel) {
+      localStorage.setItem('DEFAULT_MODEL', defaultModel);
+    } else {
+      localStorage.removeItem('DEFAULT_MODEL');
+    }
+
+    // Update model list if base URLs have changed
+    await initializeModelList();
+
+    // Notify parent component to update settings
+    onSettingsUpdate?.();
+    onOpenChange(false);
+  };
+
+  const clearApiKeys = () => {
+    // Clear all API keys from localStorage and state
+    Object.values(API_PROVIDERS).forEach(key => {
+      localStorage.removeItem(key);
+    });
+    localStorage.removeItem('OPENAI_LIKE_API_BASE_URL');
+    setApiKeys({});
+    setOpenAiLikeBaseUrl('');
+  };
+
+  return (
+    <DialogRoot open={open} onOpenChange={onOpenChange}>
+      <Dialog className="flex flex-col max-h-[85vh]">
+        <DialogTitle>Settings</DialogTitle>
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-5 py-4 space-y-4">
+            <div>
+              <button
+                onClick={() => setIsApiKeysOpen(!isApiKeysOpen)}
+                className="flex items-center justify-between w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+              >
+                <span>API Keys</span>
+                <div className={classNames("i-ph:caret-down transition-transform", {
+                  "rotate-180": isApiKeysOpen
+                })}/>
+              </button>
+              {isApiKeysOpen && (
+                <div className="mt-2 space-y-2">
+                  {Object.entries(API_PROVIDERS).map(([provider, key]) => {
+                    if (provider === 'OpenAILike') {
+                      return (
+                        <div key={key} className="space-y-2">
+                          <div className="flex flex-col gap-1">
+                            <label className="text-sm text-bolt-elements-textSecondary">OpenAI-like Base URL</label>
+                            <input
+                              type="text"
+                              value={openAiLikeBaseUrl}
+                              onChange={(e) => setOpenAiLikeBaseUrl(e.target.value)}
+                              className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+                              placeholder="Enter OpenAI-like Base URL"
+                            />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <label className="text-sm text-bolt-elements-textSecondary">OpenAI-like API Key</label>
+                            <input
+                              type="password"
+                              value={apiKeys[key] || ''}
+                              onChange={(e) => setApiKeys({...apiKeys, [key]: e.target.value})}
+                              className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+                              placeholder="Enter OpenAI-like API Key"
+                            />
+                          </div>
+                        </div>
+                      );
+                    } else if (provider === 'Ollama') {
+                      return (
+                        <div key={key} className="flex flex-col gap-1">
+                          <label className="text-sm text-bolt-elements-textSecondary">Ollama Base URL</label>
+                          <input
+                            type="text"
+                            value={ollamaBaseUrl}
+                            onChange={(e) => setOllamaBaseUrl(e.target.value)}
+                            className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+                            placeholder="Enter Ollama Base URL (without /api)"
+                          />
+                        </div>
+                      );
+                    }
+                    return (
+                      <div key={key} className="flex flex-col gap-1">
+                        <label className="text-sm text-bolt-elements-textSecondary">{provider}</label>
+                        <input
+                          type='password'
+                          value={apiKeys[key] || ''}
+                          onChange={(e) => setApiKeys({...apiKeys, [key]: e.target.value})}
+                          className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+                          placeholder={provider === 'Ollama' ? 'Enter Ollama Base URL' : `Enter ${provider} API Key`}
+                        />
+                      </div>
+                    );
+                  })}
+                  <button
+                    onClick={clearApiKeys}
+                    className="mt-4 w-full p-2 text-red-500 border border-red-500 rounded bg-red-500/10 hover:bg-bolt-elements-prompt-background"
+                  >
+                    Clear All API Keys
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm text-bolt-elements-textSecondary">Default Provider</label>
+              <select
+                value={defaultProvider}
+                onChange={(e) => setDefaultProvider(e.target.value)}
+                className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+              >
+                <option value="">Select Provider</option>
+                {Object.keys(API_PROVIDERS).map(provider => (
+                  <option key={provider} value={provider}>{provider}</option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm text-bolt-elements-textSecondary">Default Model</label>
+              <input
+                type="text"
+                value={defaultModel}
+                onChange={(e) => setDefaultModel(e.target.value)}
+                className="w-full p-2 rounded-lg border border-bolt-elements-borderColor hover:bg-gray-600 bg-bolt-elements-prompt-background text-bolt-elements-textPrimary focus:outline-none"
+                placeholder="Enter default model name"
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 p-4 mt-auto border-t border-bolt-elements-borderColor">
+          <DialogButton 
+            type="primary" 
+            onClick={() => onOpenChange(false)}
+            className="bg-transparent border border-bolt-elements-button-primary-background text-bolt-elements-button-primary-text hover:bg-bolt-elements-button-primary-background/10"
+          >
+            Cancel
+          </DialogButton>
+          <DialogButton 
+            type="primary" 
+            onClick={handleSave}
+            className="bg-blue-500 hover:bg-blue-600 text-white"
+          >
+            Save
+          </DialogButton>
+        </div>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -44,9 +44,10 @@ interface DialogButtonProps {
   type: 'primary' | 'secondary' | 'danger';
   children: ReactNode;
   onClick?: (event: React.UIEvent) => void;
+  className?: string;
 }
 
-export const DialogButton = memo(({ type, children, onClick }: DialogButtonProps) => {
+export const DialogButton = memo(({ type, children, onClick, className }: DialogButtonProps) => {
   return (
     <button
       className={classNames(
@@ -59,6 +60,7 @@ export const DialogButton = memo(({ type, children, onClick }: DialogButtonProps
           'bg-bolt-elements-button-danger-background text-bolt-elements-button-danger-text hover:bg-bolt-elements-button-danger-backgroundHover':
             type === 'danger',
         },
+        className
       )}
       onClick={onClick}
     >
@@ -84,7 +86,7 @@ export const DialogTitle = memo(({ className, children, ...props }: RadixDialog.
 export const DialogDescription = memo(({ className, children, ...props }: RadixDialog.DialogDescriptionProps) => {
   return (
     <RadixDialog.Description
-      className={classNames('px-5 py-4 text-bolt-elements-textPrimary text-md', className)}
+      className={classNames('text-bolt-elements-textPrimary text-md', className)}
       {...props}
     >
       {children}

--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -16,7 +16,12 @@ export function getAnthropicModel(apiKey: string, model: string) {
 
   return anthropic(model);
 }
-export function getOpenAILikeModel(baseURL:string,apiKey: string, model: string) {
+
+export function getOpenAILikeModel(baseURL: string, apiKey: string, model: string) {
+  if (!baseURL) {
+    throw new Error('Base URL is required for OpenAI-like providers');
+  }
+
   const openai = createOpenAI({
     baseURL,
     apiKey,
@@ -24,6 +29,7 @@ export function getOpenAILikeModel(baseURL:string,apiKey: string, model: string)
 
   return openai(model);
 }
+
 export function getOpenAIModel(apiKey: string, model: string) {
   const openai = createOpenAI({
     apiKey,
@@ -58,12 +64,16 @@ export function getGroqModel(apiKey: string, model: string) {
 }
 
 export function getOllamaModel(baseURL: string, model: string) {
-  let Ollama = ollama(model);
+  if (!baseURL) {
+    baseURL = 'http://localhost:11434';
+  }
+  
+  const Ollama = ollama(model);
   Ollama.config.baseURL = `${baseURL}/api`;
   return Ollama;
 }
 
-export function getDeepseekModel(apiKey: string, model: string){
+export function getDeepseekModel(apiKey: string, model: string) {
   const openai = createOpenAI({
     baseURL: 'https://api.deepseek.com/beta',
     apiKey,
@@ -94,14 +104,19 @@ export function getModel(provider: string, model: string, env: Env) {
     case 'OpenRouter':
       return getOpenRouterModel(apiKey, model);
     case 'Google':
-      return getGoogleModel(apiKey, model)
+      return getGoogleModel(apiKey, model);
     case 'OpenAILike':
-      return getOpenAILikeModel(baseURL,apiKey, model);
+      if (!baseURL) {
+        throw new Error('Base URL is required for OpenAI-like providers');
+      }
+      return getOpenAILikeModel(baseURL, apiKey, model);
     case 'Deepseek':
-      return getDeepseekModel(apiKey, model)
+      return getDeepseekModel(apiKey, model);
     case 'Mistral':
-      return  getMistralModel(apiKey, model);
-    default:
+      return getMistralModel(apiKey, model);
+    case 'Ollama':
       return getOllamaModel(baseURL, model);
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
   }
 }

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -11,7 +11,34 @@ export async function action(args: ActionFunctionArgs) {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
-  const { messages } = await request.json<{ messages: Messages }>();
+  const { messages, apiKeys, baseUrls, currentProvider } = await request.json<{ 
+    messages: Messages;
+    apiKeys?: Record<string, string>;
+    baseUrls?: Record<string, string>;
+    currentProvider?: string;
+  }>();
+
+  // Add API keys and base URLs to cloudflare env if provided
+  if (apiKeys) {
+    Object.entries(apiKeys).forEach(([key, value]) => {
+      if (value) {
+        context.cloudflare.env[key] = value;
+      }
+    });
+  }
+
+  if (baseUrls) {
+    Object.entries(baseUrls).forEach(([key, value]) => {
+      if (value) {
+        context.cloudflare.env[key] = value;
+      }
+    });
+  }
+
+  // Set current provider in env for model selection
+  if (currentProvider) {
+    context.cloudflare.env.CURRENT_PROVIDER = currentProvider;
+  }
 
   const stream = new SwitchableStream();
 


### PR DESCRIPTION

![SettingsModal](https://github.com/user-attachments/assets/7a867eaf-5750-4dde-bfab-8da0a914ed2d)
![Settings Icon Location](https://github.com/user-attachments/assets/f2b79085-70f1-42eb-85e8-533519a8961d)


This pull request introduces a settings modal that allows you to save API Keys, Base URL's and default model/providers to localStorage via the chat UI.

### Settings Management:
* **Settings Modal Implementation**: Added a new `SettingsModal` component to manage API keys, base URLs, and default provider/model dynamically. (`app/components/chat/SettingsModal.tsx`)
* **Settings UI Update**: Updated the `BaseChat` component to include a settings button that opens the settings modal, allowing users to manage their settings without restarting the application. (`app/components/chat/BaseChat.tsx`) [[1]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700R107-R116) [[2]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700R162-R172) [[3]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700R221-R227) [[4]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700R284-R294)

### Provider and Model Selection:
* **Dynamic Provider List**: Modified the `ModelSelector` component to dynamically include additional providers (`Ollama` and `OpenAILike`) if they are not already present in the `MODEL_LIST`. (`app/components/chat/BaseChat.tsx`) [[1]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700L25-R36) [[2]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700L45-R53)
* **Provider and Model State Management**: Updated the `BaseChat` and `Chat.client` components to load and save the selected provider and model from localStorage, ensuring persistence across sessions. (`app/components/chat/BaseChat.tsx`, `app/components/chat/Chat.client.tsx`) [[1]](diffhunk://#diff-a87a7f7c69d4bc6518b70a4fa3122ede18e570da15f12975804a87eac181c700R107-R116) [[2]](diffhunk://#diff-c3e814ea52016b5a6aa549d4a1b89d306c9ac276ba0f79a956dba166e6c84b09R102-R107) [[3]](diffhunk://#diff-c3e814ea52016b5a6aa549d4a1b89d306c9ac276ba0f79a956dba166e6c84b09R207-R208) [[4]](diffhunk://#diff-c3e814ea52016b5a6aa549d4a1b89d306c9ac276ba0f79a956dba166e6c84b09L185-R233)

### API Key Management:
* **Stored Credentials Helper**: Added a helper function to retrieve stored API keys and base URLs from localStorage, ensuring these credentials are included in requests. (`app/components/chat/Chat.client.tsx`)
* **Settings Modal Logic**: Implemented logic in the `SettingsModal` component to load, save, and clear API keys and base URLs, providing a user-friendly interface for managing these settings. (`app/components/chat/SettingsModal.tsx`)

### Documentation Update:
* **README.md Changes**: Updated the documentation to include information about the new settings management feature, guiding users on how to configure API keys and other settings via the UI. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R130)

### Other Notes:
* **Needs More Testing**: This feature has been tested in a browser using localStorage and the .env.local file, but I was unable to test with all AI APIs due to lack of access. Additionally, I do not currently have a PC that I can run Docker on, so containerized testing hasn't been done. While the implementation works as intended, there are most certainly more elegant approaches, and further testing in different environments is recommended.