### PR TITLE
Docker development profile fixes: Ollama

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ README.md
 
 # Ignore environment examples and sensitive info
 .env
-*.local
 *.example
 
 # Ignore node modules, logs and cache files

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - VITE_LOG_LEVEL=${VITE_LOG_LEVEL:-debug}
       - RUNNING_IN_DOCKER=true
     extra_hosts:
-      - "host.docker.internal:host-gateway"      
+      - "host.docker.internal:host-gateway"
     command: pnpm run dockerstart
     profiles:
       - production  # This service only runs in the production profile
@@ -31,13 +31,14 @@ services:
     image: bolt-ai:development
     build:
       target: bolt-ai-development
+    env_file: ".env.local"
     environment:
       - NODE_ENV=development
       - VITE_HMR_PROTOCOL=ws
       - VITE_HMR_HOST=localhost
       - VITE_HMR_PORT=5173
       - CHOKIDAR_USEPOLLING=true
-      - WATCHPACK_POLLING=true  
+      - WATCHPACK_POLLING=true
       - PORT=5173
       - GROQ_API_KEY=${GROQ_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
@@ -48,7 +49,7 @@ services:
       - VITE_LOG_LEVEL=${VITE_LOG_LEVEL:-debug}
       - RUNNING_IN_DOCKER=true
     extra_hosts:
-      - "host.docker.internal:host-gateway"      
+      - "host.docker.internal:host-gateway"
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
**Issue**

Docker 'development' profile has not been working well or at all for folks running Ollama. This may also relate to using other providers via a Docker-based oTToDev instance. Here's the situation:

**Setup**
- Your .env.local must specify a base URL for Ollama; http://localhost:11434 if you're running oTToDev alongside Ollama locally, http://host.docker.internal:11434 if you're running oTToDev in a container with Ollama locally. If both are in a container, they should both be on the same virtual network and you would use http://[docker vnet host for ollama]:11434. I feel that scenario is out of scope for now in terms of us providing technical support to run Ollama.

**Docker development (with Ollama running on local machine)**
- OLLAMA_BASE_API_URL in .env.local MUST be set to http://host.docker.internal:11434
- Run under docker compose: `pnpm run dockerbuild && docker compose --profile development up`
- `pnpm run dockerrun` may want to be adjusted or removed; Not focused on that just for this PR however.

**Local development (oTToDev and Ollama running on local machine)**
- OLLAMA_BASE_API_URL in .env.local MUST be set to http://localhost:11434 or http://127.0.0.1:11434
- Run development environment locally: `pnpm install && pnpm run dev`

**FIX**
- .env.local is present in .dockerignore, ensuring it will not be available during build process or when running via Docker Compose. This PR removes that.
- The `env_file` for Docker development profile is not set, this PR sets it to .env.local. **We probably want to use .env for production instead of its current state of .env.local as well**.
- I would suggest that instead of running development with .env.local, we may want to have three tiers
  - .env.local: Fully local run via `pnpm run dev`, this is actually local
  - .env.dev: We would use this for Docker while using the `development` profile
  - .env: The real .env for actual production runs.

I'd like to see if we can get some docker folks to test their environments with these changes, I know there are several solutions out there as existing Pull Requests but I feel like this one involves the least amount of future maintenance.