### PR TITLE
Fixing Ollama (and other dynamicModel providers) (re: #259)

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -132,8 +132,12 @@ const PROVIDER_LIST: ProviderInfo[] = [
 export const DEFAULT_PROVIDER = PROVIDER_LIST[0];
 
 const staticModels: ModelInfo[] = PROVIDER_LIST.map(p => p.staticModels).flat();
+const dynamiModels: ModelInfo[] = await Promise.all(PROVIDER_LIST
+  .filter((p): p is ProviderInfo & { getDynamicModels: () => Promise<ModelInfo[]> } => !!p.getDynamicModels)
+  .map(p => p.getDynamicModels())
+).then(models => models.flat());
 
-export let MODEL_LIST: ModelInfo[] = [...staticModels];
+export let MODEL_LIST: ModelInfo[] = [...staticModels, ...dynamiModels];
 
 const getOllamaBaseUrl = () => {
   const defaultBaseUrl = import.meta.env.OLLAMA_API_BASE_URL || 'http://localhost:11434';


### PR DESCRIPTION
fixes https://github.com/coleam00/bolt.new-any-llm/issues/259.

the main bug effecting #259 is that `MODEL_LIST` did not include `dynamicModels` (for providers that support it). In fact `dynamicModels` were not fetched at all, meaning this is not only breaking Ollama provider, but also any other provider + model that uses `dynamicModels`. 

that resulted in falling back to the `DEFAULT_MODEL` (i.e. `claude-3-5-sonnet-latest`) being selected as the `currentModel` because this condition always failed to find requested model:
https://github.com/coleam00/bolt.new-any-llm/blob/88700c24526bb5d722d48e51d0f2bb1cc77fb72a/app/lib/.server/llm/stream-text.ts#L51-L60


this PR constructs a list of `dynamicModels` by fetching it from all providers in parallel, and fixes `MODEL_LIST` to include those models as well.

let me know if you have any questions, and thanks for creating and maintaining this fork!
