### PR TITLE
Fix tooltip and hover text color for Export icon

### DIFF
--- a/app/components/chat/BaseChat.module.scss
+++ b/app/components/chat/BaseChat.module.scss
@@ -17,3 +17,11 @@
 .Chat {
   opacity: 1;
 }
+
+.ExportIcon:hover {
+  color: red;
+}
+
+.NavigationIcon:hover {
+  color: red;
+}

--- a/app/components/chat/ExportChatButton.tsx
+++ b/app/components/chat/ExportChatButton.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 export const ExportChatButton = ({ exportChat }: { exportChat?: () => void }) => {
   return (
     <WithTooltip tooltip="Export Chat">
-      <IconButton title="Export Chat" onClick={() => exportChat?.()}>
+      <IconButton title="Export Chat" onClick={() => exportChat?.()} className="ExportIcon">
         <div className="i-ph:download-simple text-xl"></div>
       </IconButton>
     </WithTooltip>

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -144,6 +144,7 @@ export function Menu() {
                     exportChat={exportChat}
                     onDelete={(event) => handleDeleteClick(event, item)}
                     onDuplicate={() => handleDuplicate(item.id)}
+                    className="NavigationIcon"
                   />
                 ))}
               </div>


### PR DESCRIPTION
Fixes #409

Fix the blank tooltip for the Export icon and add hover text color changes for navigation icons.

* **Tooltip Fix:**
  - Set the tooltip content for the Export icon to "Export Chat" in `app/components/chat/ExportChatButton.tsx`.

* **Hover Text Color Change:**
  - Add CSS rule to change text color of `.ExportIcon` to red on hover in `app/components/chat/BaseChat.module.scss`.
  - Add CSS rule to change text color of other navigation icons to red on hover in `app/components/chat/BaseChat.module.scss`.
  - Add class `ExportIcon` to the `IconButton` component in `app/components/chat/ExportChatButton.tsx`.
  - Add class `NavigationIcon` to other navigation icons in `app/components/sidebar/Menu.client.tsx`.

