### PR TITLE
Fix for exo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ _worker.bundle
 
 Modelfile
 modelfiles
+.direnv

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -320,7 +320,10 @@ async function getOpenAILikeModels(): Promise<ModelInfo[]> {
     });
     const res = (await response.json()) as any;
 
-    return res.data.map((model: any) => ({
+    // When using the OpenAI-compatible endpoint from Exo, the data is not at `res.data` but `res` directly.
+    const d = res.data ? res.data : res;
+
+    return d.map((model: any) => ({
       name: model.id,
       label: model.id,
       provider: 'OpenAILike',

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Environment flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem(system:
+    let pkgs = nixpkgs.legacyPackages.${system}; in
+    {
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          nodejs_23
+          pnpm
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
When using the OpenAI compatible endpoint of [Exo](https://github.com/exo-explore/exo), getting `v1/models` will not expose the model list at `data` but rather return it directly:

```bash
$ curl http://192.168.10.118:52415/v1/models
```
```json
[
    {
        "id": "llama-3.2-1b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.2-3b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.1-8b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.1-70b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.1-70b-bf16",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3-8b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3-70b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.1-405b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llama-3.1-405b-8bit",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "mistral-nemo",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "mistral-large",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "deepseek-coder-v2-lite",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "deepseek-coder-v2.5",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "llava-1.5-7b-hf",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-0.5b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-coder-1.5b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-coder-3b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-coder-7b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-coder-14b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-coder-32b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-7b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-math-7b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-14b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-72b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "qwen-2.5-math-72b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "nemotron-70b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "nemotron-70b-bf16",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "gemma2-9b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "gemma2-27b",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    },
    {
        "id": "dummy",
        "object": "model",
        "owned_by": "exo",
        "ready": true
    }
]
```

This led to an error when retrieving the model list because `res.data` was `undefined` in `app/utils/constants.ts` line 323.

My quick fix checks if `res.data` is there and uses it, otherwise, it uses `res` directly.

I also added a Nix flake and direnv configuration for people using Nix (Darwin or OS) with direnv to manage their development environments.