### PR TITLE
Test LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,24 @@ pnpm run dev
 
 This will start the Remix Vite development server. You will need Google Chrome Canary to run this locally if you use Chrome! It's an easy install and a good browser for web development anyway.
 
+### Development with VSCode
+
+Add the following launch configuration to your `.vscode/launch.json`
+
+```json
+{
+  "name": "pnpm dev",
+  "type": "node",
+  "request": "launch",
+  "program": "${workspaceFolder}/node_modules/pnpm/bin/pnpm.cjs",
+  "args": [
+    "dev"
+  ],
+  "console": "integratedTerminal",
+  "internalConsoleOptions": "neverOpen"
+}
+```
+
 ## FAQ
 
 ### How do I get the best results with oTToDev?

--- a/app/lib/.server/llm/getMockParrotModel.ts
+++ b/app/lib/.server/llm/getMockParrotModel.ts
@@ -1,0 +1,60 @@
+import type { LanguageModelV1, LanguageModelV1CallOptions } from 'ai';
+
+export function getMockParrotModel() {
+  return {
+    specificationVersion: 'v1',
+    provider: 'MockParrot',
+    modelId: 'mock-parrot-model',
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportsStructuredOutputs: false,
+    async doGenerate(options: LanguageModelV1CallOptions) {
+      const text = options.prompt
+        .map((message) => {
+          if (message.role === 'user' && Array.isArray(message.content)) {
+            return message.content.map((part) => (part.type === 'text' ? part.text : '')).join('');
+          }
+
+          return '';
+        })
+        .join('');
+      return {
+        text,
+        finishReason: 'stop',
+        usage: {
+          promptTokens: text.length,
+          completionTokens: text.length,
+        },
+        rawCall: {
+          rawPrompt: options.prompt,
+          rawSettings: options,
+        },
+      };
+    },
+    async doStream(options: LanguageModelV1CallOptions) {
+      const text = options.prompt
+        .map((message) => {
+          if (message.role === 'user' && Array.isArray(message.content)) {
+            return message.content.map((part) => (part.type === 'text' ? part.text : '')).join('');
+          }
+
+          return '';
+        })
+        .join('');
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: 'text-delta', textDelta: text });
+          controller.close();
+        },
+      });
+
+      return {
+        stream,
+        rawCall: {
+          rawPrompt: options.prompt,
+          rawSettings: options,
+        },
+      };
+    },
+  } as LanguageModelV1;
+}

--- a/app/lib/.server/llm/model.ts
+++ b/app/lib/.server/llm/model.ts
@@ -11,6 +11,7 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { createMistral } from '@ai-sdk/mistral';
 import { createCohere } from '@ai-sdk/cohere';
 import type { LanguageModelV1 } from 'ai';
+import { getMockParrotModel } from '~/lib/.server/llm/getMockParrotModel';
 
 export const DEFAULT_NUM_CTX = process.env.DEFAULT_NUM_CTX ? parseInt(process.env.DEFAULT_NUM_CTX, 10) : 32768;
 
@@ -23,6 +24,7 @@ export function getAnthropicModel(apiKey: OptionalApiKey, model: string) {
 
   return anthropic(model);
 }
+
 export function getOpenAILikeModel(baseURL: string, apiKey: OptionalApiKey, model: string) {
   const openai = createOpenAI({
     baseURL,
@@ -156,6 +158,8 @@ export function getModel(provider: string, model: string, env: Env, apiKeys?: Re
       return getXAIModel(apiKey, model);
     case 'Cohere':
       return getCohereAIModel(apiKey, model);
+    case 'MockParrot':
+      return getMockParrotModel();
     default:
       return getOllamaModel(baseURL, model);
   }

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -100,7 +100,8 @@ export class ActionRunner {
       .catch((error) => {
         console.error('Action failed:', error);
       });
-      return this.#currentExecutionPromise;
+
+    await this.#currentExecutionPromise;
   }
 
   async #executeAction(actionId: string, isStreaming: boolean = false) {

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -4,8 +4,8 @@ import type { ProviderInfo } from '~/types/model';
 export const WORK_DIR_NAME = 'project';
 export const WORK_DIR = `/home/${WORK_DIR_NAME}`;
 export const MODIFICATIONS_TAG_NAME = 'bolt_file_modifications';
-export const MODEL_REGEX = /^\[Model: (.*?)\]\n\n/;
-export const PROVIDER_REGEX = /\[Provider: (.*?)\]\n\n/;
+export const MODEL_REGEX = /^\[Model: (.*?)]\n\n/;
+export const PROVIDER_REGEX = /\[Provider: (.*?)]\n\n/;
 export const DEFAULT_MODEL = 'claude-3-5-sonnet-latest';
 
 const PROVIDER_LIST: ProviderInfo[] = [
@@ -212,7 +212,6 @@ const PROVIDER_LIST: ProviderInfo[] = [
     ],
     getApiKeyLink: 'https://huggingface.co/settings/tokens',
   },
-
   {
     name: 'OpenAI',
     staticModels: [
@@ -261,6 +260,15 @@ const PROVIDER_LIST: ProviderInfo[] = [
   },
 ];
 
+if (process.env.NODE_ENV === 'test') {
+  PROVIDER_LIST.push({
+    name: 'MockParrot',
+    staticModels: [
+      { name: 'parrot', label: 'Parrot (Mock)', provider: 'MockParrot', maxTokenAllowed: Number.MAX_VALUE },
+    ],
+  });
+}
+
 export const DEFAULT_PROVIDER = PROVIDER_LIST[0];
 
 const staticModels: ModelInfo[] = PROVIDER_LIST.map((p) => p.staticModels).flat();
@@ -283,9 +291,11 @@ const getOllamaBaseUrl = () => {
 };
 
 async function getOllamaModels(): Promise<ModelInfo[]> {
-  //if (typeof window === 'undefined') {
-    //return [];
-  //}
+  /*
+   * if (typeof window === 'undefined') {
+   * return [];
+   * }
+   */
 
   try {
     const baseUrl = getOllamaBaseUrl();

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "husky": "9.1.7",
     "is-ci": "^3.0.1",
     "node-fetch": "^3.3.2",
+    "pnpm": "9.14.4",
     "prettier": "^3.3.2",
     "sass-embedded": "^1.80.3",
     "typescript": "^5.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
+      pnpm:
+        specifier: 9.14.4
+        version: 9.14.4
       prettier:
         specifier: ^3.3.2
         version: 3.3.2
@@ -4405,6 +4408,11 @@ packages:
 
   pkg-types@1.1.1:
     resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
+
+  pnpm@9.14.4:
+    resolution: {integrity: sha512-yBgLP75OS8oCyUI0cXiWtVKXQKbLrfGfp4JUJwQD6i8n1OHUagig9WyJtj3I6/0+5TMm2nICc3lOYgD88NGEqw==}
+    engines: {node: '>=18.12'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -10600,6 +10608,8 @@ snapshots:
       confbox: 0.1.7
       mlly: 1.7.1
       pathe: 1.1.2
+
+  pnpm@9.14.4: {}
 
   possible-typed-array-names@1.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
+    "sourceMap": true,
 
     // vite takes care of building everything, not tsc
     "noEmit": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig((config) => {
   return {
     build: {
       target: 'esnext',
+      sourcemap: true,
     },
     plugins: [
       nodePolyfills({
@@ -27,7 +28,7 @@ export default defineConfig((config) => {
       chrome129IssuePlugin(),
       config.mode === 'production' && optimizeCssModules({ apply: 'build' }),
     ],
-    envPrefix:["VITE_","OPENAI_LIKE_API_","OLLAMA_API_BASE_URL","LMSTUDIO_API_BASE_URL"],
+    envPrefix: ['VITE_', 'OPENAI_LIKE_API_', 'OLLAMA_API_BASE_URL', 'LMSTUDIO_API_BASE_URL'],
     css: {
       preprocessorOptions: {
         scss: {


### PR DESCRIPTION
# Motivation

in order to be able to test with integration character (e. g. using playwright), the subject under test must not rely on external interfaces.

# What's inside

This PR adds a mock llm provider for integration testing purposes.
The provider only appears in `NODE_ENV=test. It echoes all requests sent to it (including the context.)

This will allow to do integration testing without requiring any external connection.
By sending prepared commands which include bolt action tags (like <boltAction>), things like rendering can be tested E2E.