### PR TITLE
Unfinished refactoring and cleanup of provider settings

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -26,6 +26,7 @@ import GitCloneButton from './GitCloneButton';
 import FilePreview from './FilePreview';
 import { ModelSelector } from '~/components/chat/ModelSelector';
 import { SpeechRecognitionButton } from '~/components/chat/SpeechRecognition';
+import { getProvidersInitialState } from '~/components/settings/getProvidersInitialState';
 
 const TEXTAREA_MIN_HEIGHT = 76;
 
@@ -109,24 +110,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
     const [transcript, setTranscript] = useState('');
 
     // Load enabled providers from cookies
-    const [enabledProviders, setEnabledProviders] = useState(() => {
-      const savedProviders = Cookies.get('providers');
-
-      if (savedProviders) {
-        try {
-          const parsedProviders = JSON.parse(savedProviders);
-          return PROVIDER_LIST.filter((p) => parsedProviders[p.name]);
-        } catch (error) {
-          console.error('Failed to parse providers from cookies:', error);
-          return PROVIDER_LIST;
-        }
-      }
-
-      return PROVIDER_LIST;
-    });
+    const [enabledProviders, setEnabledProviders] = useState(getProvidersInitialState(PROVIDER_LIST));
 
     // Update enabled providers when cookies change
     useEffect(() => {
+
       const updateProvidersFromCookies = () => {
         const savedProviders = Cookies.get('providers');
 

--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -2,6 +2,7 @@ import type { ProviderInfo } from '~/types/model';
 import type { ModelInfo } from '~/utils/types';
 import { useEffect, useState } from 'react';
 import Cookies from 'js-cookie';
+import { getProvidersInitialState } from '~/components/settings/getProvidersInitialState';
 
 interface ModelSelectorProps {
   model?: string;
@@ -22,21 +23,7 @@ export const ModelSelector = ({
   providerList,
 }: ModelSelectorProps) => {
   // Load enabled providers from cookies
-  const [enabledProviders, setEnabledProviders] = useState(() => {
-    const savedProviders = Cookies.get('providers');
-
-    if (savedProviders) {
-      try {
-        const parsedProviders = JSON.parse(savedProviders);
-        return providerList.filter((p) => parsedProviders[p.name]);
-      } catch (error) {
-        console.error('Failed to parse providers from cookies:', error);
-        return providerList;
-      }
-    }
-
-    return providerList;
-  });
+  const [enabledProviders, setEnabledProviders] = useState(getProvidersInitialState(providerList));
 
   // Update enabled providers when cookies change
   useEffect(() => {

--- a/app/components/settings/SettingsWindow.tsx
+++ b/app/components/settings/SettingsWindow.tsx
@@ -12,6 +12,7 @@ import commit from '~/commit.json';
 import Cookies from 'js-cookie';
 import styles from './Settings.module.scss';
 import { Switch } from '~/components/ui/Switch';
+import { getProvidersInitialState } from '~/components/settings/getProvidersInitialState';
 
 interface SettingsProps {
   open: boolean;
@@ -81,25 +82,7 @@ export const SettingsWindow = ({ open, onClose }: SettingsProps) => {
   ];
 
   // Load providers from cookies on mount
-  const [providers, setProviders] = useState(() => {
-    const savedProviders = Cookies.get('providers');
-
-    if (savedProviders) {
-      try {
-        const parsedProviders = JSON.parse(savedProviders);
-
-        // Merge saved enabled states with the base provider list
-        return providersList.map((provider) => ({
-          ...provider,
-          isEnabled: parsedProviders[provider.name] || false,
-        }));
-      } catch (error) {
-        console.error('Failed to parse providers from cookies:', error);
-      }
-    }
-
-    return providersList;
-  });
+  const [providers, setProviders] = useState(getProvidersInitialState(providersList));
 
   const handleToggleProvider = (providerName: string, enabled: boolean) => {
     setProviders((prevProviders) => {
@@ -372,16 +355,14 @@ export const SettingsWindow = ({ open, onClose }: SettingsProps) => {
                         <h3 className="text-lg font-medium text-bolt-elements-textPrimary mb-4">Optional Features</h3>
                         <div className="flex items-center justify-between mb-2">
                           <span className="text-bolt-elements-textPrimary">Debug Info</span>
-                          <Switch
-                            className="ml-auto"
-                            checked={isDebugEnabled}
-                            onCheckedChange={handleToggleDebug}
-                          />
+                          <Switch className="ml-auto" checked={isDebugEnabled} onCheckedChange={handleToggleDebug} />
                         </div>
                       </div>
 
                       <div className="mb-6 border-t border-bolt-elements-borderColor pt-4">
-                        <h3 className="text-lg font-medium text-bolt-elements-textPrimary mb-4">Experimental Features</h3>
+                        <h3 className="text-lg font-medium text-bolt-elements-textPrimary mb-4">
+                          Experimental Features
+                        </h3>
                         <p className="text-sm text-bolt-elements-textSecondary mb-4">
                           Disclaimer: Experimental features may be unstable and are subject to change.
                         </p>
@@ -439,7 +420,9 @@ export const SettingsWindow = ({ open, onClose }: SettingsProps) => {
                       <h3 className="text-lg font-medium text-bolt-elements-textPrimary mb-4">GitHub Connection</h3>
                       <div className="flex mb-4">
                         <div className="flex-1 mr-2">
-                          <label className="block text-sm text-bolt-elements-textSecondary mb-1">GitHub Username:</label>
+                          <label className="block text-sm text-bolt-elements-textSecondary mb-1">
+                            GitHub Username:
+                          </label>
                           <input
                             type="text"
                             value={githubUsername}
@@ -448,7 +431,9 @@ export const SettingsWindow = ({ open, onClose }: SettingsProps) => {
                           />
                         </div>
                         <div className="flex-1">
-                          <label className="block text-sm text-bolt-elements-textSecondary mb-1">Personal Access Token:</label>
+                          <label className="block text-sm text-bolt-elements-textSecondary mb-1">
+                            Personal Access Token:
+                          </label>
                           <input
                             type="password"
                             value={githubToken}

--- a/app/components/settings/getProvidersInitialState.ts
+++ b/app/components/settings/getProvidersInitialState.ts
@@ -1,0 +1,21 @@
+import Cookies from 'js-cookie';
+
+export function getProvidersInitialState(providersList: { name: string }[]) {
+  return () => {
+    const savedProviders = Cookies.get('providers');
+    let parsedProviders = {};
+
+    if (savedProviders) {
+      try {
+        parsedProviders = JSON.parse(savedProviders);
+      } catch (error) {
+        console.error('Failed to parse providers from cookies:', error);
+      }
+    }
+
+    return providersList.map((provider) => ({
+      ...provider,
+      isEnabled: parsedProviders.hasOwnProperty(provider.name) ? parsedProviders.hasOwnProperty[provider.name] : true,
+    }));
+  };
+}


### PR DESCRIPTION
Was testing latest version in the morning and found issues with current provider settings that I started fixing but could no finish:
- lot of duplicated code, trying to make one function that manages it all
- if cookies are not set providers show disabled in settings while they are enabled in dropdown, if you touch one of the settings they are saved as disabled and user has no providers or just one, that is broken
- I also saw that state sharing is done trough interval and cookies, that is not React way, that state should be risen up to common parent and propagated down, or some global state container should be used

These are plans for fixes