### PR TITLE
fix: enabled model provider selection

### DIFF
--- a/app/lib/hooks/useSettings.tsx
+++ b/app/lib/hooks/useSettings.tsx
@@ -23,7 +23,7 @@ export function useSettings() {
             ...currentProvider,
             settings: {
               ...parsedProviders[provider],
-              enabled: parsedProviders[provider].enabled || true,
+              enabled: parsedProviders[provider].enabled ?? true,
             },
           });
         });


### PR DESCRIPTION
When testing the provider selection appeared to be resetting after a refresh, this corrects that.