### PR TITLE
fix: prevent message sending during shift key press and IME composition

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -420,7 +420,16 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                     }}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
+                        // Prevent sending message when shift key is pressed
                         if (event.shiftKey) {
+                          return;
+                        }
+
+                        /*
+                         * Prevent sending message when IME composition is in progress
+                         * keyCode 229 is a special code for IME composition with some browsers like MacOS Safari
+                         */
+                        if (event.nativeEvent.isComposing || event.keyCode === 229) {
                           return;
                         }
 


### PR DESCRIPTION
HI. I found an issue when typing in a nonalphabetical language like Japanese.

In languages that use an Input Method Editor (IME), such as Japanese, the 'Enter' key is used to confirm character conversions. Thus, when typing in Japanese on the chat screen, pressing the 'Enter' key to select a Kanji would inadvertently send an incomplete message. 

This update addresses and resolves this issue.

<img width="698" alt="image" src="https://github.com/user-attachments/assets/9e10c705-bf00-4f05-a5b1-f4b2a95d80f1" />
