### PR TITLE
Correct docker network issue in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: bolt-ai-production
+    network_mode: host
     ports:
       - "5173:5173"
     env_file: ".env.local"
@@ -35,6 +36,7 @@ services:
     image: bolt-ai:development
     build:
       target: bolt-ai-development
+    network_mode: host
     environment:
       - NODE_ENV=development
       - VITE_HMR_PROTOCOL=ws


### PR DESCRIPTION
Updated Docker Compose file to fix an error which was preventing the docker container from seeing other containers and local llm's through ollama and LMstudio on linux.

With the old variation docker was creating a network specifically for this container which did not have access to localhost or other containers. This change forces the container to use the 'host' docker network allowing access to the bare metal llms.

If this conflicts with the way docker works on Windows or Mac then maybe comment it out and add a comment to uncomment if having the above noted issues???

Please note, this is my first ever pull request. If i've gotten something wrong please let me know so i can fix it for next time.