### PR TITLE
docs: add link to bolt.new issue tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bolt.new related issues
+    url: https://github.com/stackblitz/bolt.new/issues/new/choose
+    about: Report issues related to Bolt.new (not Bolt.diy)
+  - name: Chat
+    url: https://thinktank.ottomator.ai
+    about: Ask questions and discuss with other Bolt.diy users.


### PR DESCRIPTION
- Adds link to `bolt.new` issue tracked in issue template, so that users would not report unrelated bugs to this repository
- Adds link to ottomator chat, so that users can find more info for issues there

<img src="https://github.com/user-attachments/assets/2e75f540-ff51-4191-8d7b-9f6ae619e86c" width="400" />
