### PR TITLE
fix: package.json dev command semicolon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "deploy": "npm run build && wrangler pages deploy",
     "build": "remix vite:build",
-    "dev": "node pre-start.cjs;  remix vite:dev",
+    "dev": "node pre-start.cjs && remix vite:dev",
     "test": "vitest --run",
     "test:watch": "vitest",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint app",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change modifies the `dev` script to use `&&` instead of `;` to ensure that `remix vite:dev` only runs if `node pre-start.cjs` completes successfully.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Modified the `dev` script to use `&&` instead of `;` to ensure sequential execution.