### PR TITLE
Move Ollama to beginning of PROVIDER_LIST

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -15,6 +15,14 @@ const logger = createScopedLogger('Constants');
 
 const PROVIDER_LIST: ProviderInfo[] = [
   {
+    name: 'Ollama',
+    staticModels: [],
+    getDynamicModels: getOllamaModels,
+    getApiKeyLink: 'https://ollama.com/download',
+    labelForGetApiKey: 'Download Ollama',
+    icon: 'i-ph:cloud-arrow-down',
+  },
+  {
     name: 'Anthropic',
     staticModels: [
       {
@@ -41,6 +49,7 @@ const PROVIDER_LIST: ProviderInfo[] = [
     ],
     getApiKeyLink: 'https://console.anthropic.com/settings/keys',
   },
+  /*
   {
     name: 'Ollama',
     staticModels: [],
@@ -49,6 +58,7 @@ const PROVIDER_LIST: ProviderInfo[] = [
     labelForGetApiKey: 'Download Ollama',
     icon: 'i-ph:cloud-arrow-down',
   },
+  */
   {
     name: 'OpenAILike',
     staticModels: [],


### PR DESCRIPTION
This is definitely not a fix, however, it prevented issues I found with using Ollama (i.e., localhost, internal, or external ip). The following are a few of the issues I found that noted the same problem: #259 #353 #423 

1) Ollama displays the Anthropic models in it's models dropdown
2) Ollama defaults to claude-3-5-sonnet-latest as it is the DEFAULT_MODEL in constants.ts

### Tested with
Bolt.diy on commit 8c7a9f750fac38228af1dfd0e8c2a705315f0792
Mac OS: 15.2
Colima (Docker): v0.8.0
docker-compose --profile development up --build (SUCCESS)
docker-compose --profile production up --build (SUCCESS)

Ollama will default to localhost (i.e. how the app is coded), however, you can easily go into _Settings_ on the side menu and go under _Providers_ and change the _Ollama Base URL_ to another ip. _A page refresh may be required afterwards_. 
Another issue: after page load or refresh the dropdown is dynamically generated and will often default back to claude-3-5-sonnet-latest. The solution I found for this was to open the dropdown, select a different provider, and then select the original provider.

Using .env.local was a whole other charlie foxtrot (i.e., issues #68 & #221) as --env .env.local did not work effectively, so I suggest just using the settings menu.

Hoping that #396 is implemented to overcome or alleviate some of these issues.

Additional notes:
There was another way to workaround this issue by hardcoding a provider value:

> (app/utils/constants.ts) Line 307: export const DEFAULT_PROVIDER = PROVIDER_LIST[0];

And the removing references to the object key DEFAULT_PROVIDER.**name** in app/lib/.server/stream-text.ts. That is an even less ideal workaround than the one proposed. I chose the simpler of the two.