### PR TITLE
Explain support for Google Generative AI and Google Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,9 @@ OPEN_ROUTER_API_KEY=
 
 # Get your Google Generative AI API Key by following these instructions -
 # https://console.cloud.google.com/apis/credentials
-# You only need this environment variable set if you want to use Google Generative AI models
+# Get your Google Gemini API Key from the Google AI Studio dashboard -
+# https://aistudio.google.com/app/apikey
+# You only need this environment variable set if you want to use Google Generative AI models or Google Gemini models
 GOOGLE_GENERATIVE_AI_API_KEY=
 
 # You only need this environment variable set if you want to use oLLAMA models


### PR DESCRIPTION
This PR extends information for integrating and Google Gemini models into our application. The existing environment variable, GOOGLE_GENERATIVE_AI_API_KEY, can be used for both Google Generative Cloud and Gemini. Same key can be used for accessing these services. 
I did not want to clutter the dropdown list by adding another "Google Gemini" option for the "Google" option works for both already. 