### PR TITLE
doc: README formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://thinktank.ottomator.ai
 - ✅ Mobile friendly (@qwikode)
 - ✅ Better prompt enhancing (@SujalXplores)
 - ✅ Attach images to prompts (@atrokhym)
-- ✅ Detect package.json and commands to auto install and run preview for folder and git import (@wonderwhy-er)
+- ✅ Detect package.json and commands to auto install & run preview for folder and git import (@wonderwhy-er)
 - ✅ Selection tool to target changes visually (@emcconnell)
 - ⬜ **HIGH PRIORITY** - Prevent bolt from rewriting files as often (file locking and diffs)
 - ⬜ **HIGH PRIORITY** - Better prompting for smaller LLMs (code window sometimes doesn't start)


### PR DESCRIPTION
Changed 'and' to '&' so that it would fit on one line.

Before:
![before](https://github.com/user-attachments/assets/3a312916-7d88-46a0-ade9-a8b9b8e05b0a)


After:
![after](https://github.com/user-attachments/assets/40c99895-a7f4-4f0e-acb1-e0ddb2860d08)
