### PR TITLE
fix: update vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,8 @@ export default defineConfig((config) => {
         future: {
           v3_fetcherPersist: true,
           v3_relativeSplatPath: true,
-          v3_throwAbortReason: true
+          v3_throwAbortReason: true,
+          v3_lazyRouteDiscovery: true
         },
       }),
       UnoCSS(),


### PR DESCRIPTION
added v3_lazyRouteDiscovery to the fvite.config.ts without any side effects. this removes the warning in terminal