### PR TITLE
fix: warn Constants Failed 

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -499,8 +499,6 @@ async function getLMStudioModels(_apiKeys?: Record<string, string>, settings?: I
     }));
   } catch (e: any) {
     logStore.logError('Failed to get LMStudio models', e, { baseUrl: settings?.baseUrl });
-    logger.warn('Failed to get LMStudio models: ', e.message || '');
-
     return [];
   }
 }


### PR DESCRIPTION
fixes the 'WARN Constants Failed to get LMStudio models:  fetch failed' error as the user most likely just has it active in provider