### PR TITLE
fix: charactors to vaild list for titles

### DIFF
--- a/app/lib/hooks/useEditChatDescription.ts
+++ b/app/lib/hooks/useEditChatDescription.ts
@@ -92,7 +92,8 @@ export function useEditChatDescription({
     }
 
     const lengthValid = trimmedDesc.length > 0 && trimmedDesc.length <= 100;
-    const characterValid = /^[a-zA-Z0-9\s]+$/.test(trimmedDesc);
+    // Allow letters, numbers, spaces, and common punctuation but exclude characters that could cause issues
+    const characterValid = /^[a-zA-Z0-9\s\-_.,!?()[\]{}'"]+$/.test(trimmedDesc);
 
     if (!lengthValid) {
       toast.error('Description must be between 1 and 100 characters.');
@@ -100,7 +101,7 @@ export function useEditChatDescription({
     }
 
     if (!characterValid) {
-      toast.error('Description can only contain alphanumeric characters and spaces.');
+      toast.error('Description can only contain letters, numbers, spaces, and basic punctuation.');
       return false;
     }
 


### PR DESCRIPTION
added common punctuation to the charactersValid. This was because the chat titles where using some of these and when you edited the title  you would have to find these punctuation's and remove them.