### PR TITLE
chore: updating copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 StackBlitz, Inc.
+Copyright (c) 2024 StackBlitz, Inc. and bolt.diy contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updating copyright in LICENSE from "Copyright (c) 2024 StackBlitz, Inc." to Copyright (c) 2024 StackBlitz, Inc. and bolt.diy contributors."

@patak-dev sorry for the multiple pings, I had to correct the pull request!