### PR TITLE
fix: __COMMIT_HASH and __APP_VERSION refactor trailing underscores

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,8 +20,8 @@ const getGitHash = () => {
 export default defineConfig((config) => {
   return {
     define: {
-      __COMMIT_HASH__: JSON.stringify(getGitHash()),
-      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+      __COMMIT_HASH: JSON.stringify(getGitHash()),
+      __APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
     build: {
       target: 'esnext',


### PR DESCRIPTION
These moved to vite.config.ts with trailing underscores, which was crashing useSettings hook and DebugTab.tsx. Removal of these underscores fixes both #851 and #852 for me, please review.