### PR TITLE
feat: added a check for api keys and baseURL's

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -210,6 +210,25 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
 
     const handleSendMessage = (event: React.UIEvent, messageInput?: string) => {
       if (sendMessage) {
+        // Check if provider exists and is not experimental
+        if (provider) {
+          const isExperimental = ['Ollama', 'LMStudio', 'OpenAILike'].includes(provider.name);
+          
+          if (isExperimental) {
+            // For experimental providers, check if base URL is set
+            if (!provider.settings?.baseUrl) {
+              toast.error(`Please set a base URL for ${provider.name} in the model settings`);
+              return;
+            }
+          } else {
+            // For non-experimental providers, check if API key is set
+            if (!apiKeys[provider.name]) {
+              toast.error(`Please set an API key for ${provider.name} in the model settings`);
+              return;
+            }
+          }
+        }
+
         sendMessage(event, messageInput);
 
         if (recognition) {


### PR DESCRIPTION
if the provider is Ollama, LM Studio or OpenAI Like it will require a baseURL the others require an API key. Show toast and not send if these are not met.
![1](https://github.com/user-attachments/assets/59bbbd03-2b45-4cbf-b838-b437f535407a)
![2](https://github.com/user-attachments/assets/bf7e108d-277c-489c-ab88-d2dbb58f1633)
