### PR TITLE
fix: detect and remove markdown block syntax that llms sometimes hallucinate for file actions

### DIFF
--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -95,6 +95,16 @@ export class StreamingMessageParser {
             let content = currentAction.content.trim();
 
             if ('type' in currentAction && currentAction.type === 'file') {
+              // Remove markdown code block syntax if present and file is not markdown
+              if (!currentAction.filePath.endsWith('.md')) {
+                const codeBlockRegex = /^\s*```\w*\n([\s\S]*?)\n\s*```\s*$/;
+                const match = content.match(codeBlockRegex);
+
+                if (match) {
+                  content = match[1].replace(/^[ ]{4}/gm, '').trim(); // Remove common leading 4-space indent
+                }
+              }
+
               content += '\n';
             }
 

--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -101,7 +101,7 @@ export class StreamingMessageParser {
                 const match = content.match(codeBlockRegex);
 
                 if (match) {
-                  content = match[1].replace(/^[ ]{4}/gm, '').trim(); // Remove common leading 4-space indent
+                  content = match[1]; // Remove common leading 4-space indent
                 }
               }
 

--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -52,6 +52,17 @@ interface MessageState {
   actionId: number;
 }
 
+function cleanoutMarkdownSyntax(content: string) {
+  const codeBlockRegex = /^\s*```\w*\n([\s\S]*?)\n\s*```\s*$/;
+  const match = content.match(codeBlockRegex);
+  console.log('matching', !!match, content);
+
+  if (match) {
+    return match[1]; // Remove common leading 4-space indent
+  } else {
+    return content;
+  }
+}
 export class StreamingMessageParser {
   #messages = new Map<string, MessageState>();
 
@@ -97,12 +108,8 @@ export class StreamingMessageParser {
             if ('type' in currentAction && currentAction.type === 'file') {
               // Remove markdown code block syntax if present and file is not markdown
               if (!currentAction.filePath.endsWith('.md')) {
-                const codeBlockRegex = /^\s*```\w*\n([\s\S]*?)\n\s*```\s*$/;
-                const match = content.match(codeBlockRegex);
-
-                if (match) {
-                  content = match[1]; // Remove common leading 4-space indent
-                }
+                content = cleanoutMarkdownSyntax(content);
+                console.log('content after cleanup', content);
               }
 
               content += '\n';
@@ -130,7 +137,11 @@ export class StreamingMessageParser {
             i = closeIndex + ARTIFACT_ACTION_TAG_CLOSE.length;
           } else {
             if ('type' in currentAction && currentAction.type === 'file') {
-              const content = input.slice(i);
+              let content = input.slice(i);
+
+              if (!currentAction.filePath.endsWith('.md')) {
+                content = cleanoutMarkdownSyntax(content);
+              }
 
               this._options.callbacks?.onActionStream?.({
                 artifactId: currentArtifact.id,


### PR DESCRIPTION
### Reason for Change
Sometimes AI responds with files wrapped in markdown code block syntax, causing issues and wasting tokens. The goal is to clean this up for non-Markdown files to improve efficiency and output clarity.

### What Was Done
- Added logic in message-parser.ts to detect and remove markdown code block syntax for non-Markdown files using regex.
- lint:fix made minor formatting and readability improvements in DataTab.tsx

### Example Chat for Testing where problem is present
https://gist.github.com/wonderwhy-er/969023d7146a5f3e3ec90ec99ba4bc4e