### PR TITLE
fix: add defaults for LMStudio to work out of the box

### DIFF
--- a/app/lib/modules/llm/base-provider.ts
+++ b/app/lib/modules/llm/base-provider.ts
@@ -29,7 +29,12 @@ export abstract class BaseProvider implements ProviderInfo {
     }
 
     const baseUrlKey = this.config.baseUrlKey || defaultBaseUrlKey;
-    let baseUrl = settingsBaseUrl || serverEnv?.[baseUrlKey] || process?.env?.[baseUrlKey] || manager.env?.[baseUrlKey];
+    let baseUrl =
+      settingsBaseUrl ||
+      serverEnv?.[baseUrlKey] ||
+      process?.env?.[baseUrlKey] ||
+      manager.env?.[baseUrlKey] ||
+      this.config.baseUrl;
 
     if (baseUrl && baseUrl.endsWith('/')) {
       baseUrl = baseUrl.slice(0, -1);

--- a/app/lib/modules/llm/providers/lmstudio.ts
+++ b/app/lib/modules/llm/providers/lmstudio.ts
@@ -12,6 +12,7 @@ export default class LMStudioProvider extends BaseProvider {
 
   config = {
     baseUrlKey: 'LMSTUDIO_API_BASE_URL',
+    baseUrl: 'http://localhost:1234/',
   };
 
   staticModels: ModelInfo[] = [];

--- a/app/lib/modules/llm/types.ts
+++ b/app/lib/modules/llm/types.ts
@@ -28,5 +28,6 @@ export interface ProviderInfo {
 }
 export interface ProviderConfig {
   baseUrlKey?: string;
+  baseUrl?: string;
   apiTokenKey?: string;
 }


### PR DESCRIPTION
**Reason for change:**
Was testing LMStudio today based on bug report.
Was surprised that it does not work out of the box anymore.\

**What changed:**
- added baseUrl to provider configs
- made it last options after other ones are undefined
- for LMStudio added baseUrl: 'http://localhost:1234/ as that is one that LMStudio sets by default
- tested that now it works without need to change anything in LMStudio or Bolt out of the box