### PR TITLE
feat: enhance chat import with multi-format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ bolt.diy was originally started by [Cole Medin](https://www.youtube.com/@ColeMed
 - ✅ Bolt terminal to see the output of LLM run commands (@thecodacus)
 - ✅ Streaming of code output (@thecodacus)
 - ✅ Ability to revert code to earlier version (@wonderwhy-er)
+- ✅ Chat history backup and restore functionality (@sidbetatester)
 - ✅ Cohere Integration (@hasanraiyan)
 - ✅ Dynamic model max token length (@hasanraiyan)
 - ✅ Better prompt enhancing (@SujalXplores)

--- a/app/components/chat/chatExportAndImport/ImportButtons.tsx
+++ b/app/components/chat/chatExportAndImport/ImportButtons.tsx
@@ -2,6 +2,15 @@ import type { Message } from 'ai';
 import { toast } from 'react-toastify';
 import { ImportFolderButton } from '~/components/chat/ImportFolderButton';
 
+type ChatData = {
+  messages?: Message[]; // Standard Bolt format
+  description?: string; // Optional description
+  history?: Array<{ messages: Message[]; description?: string }>; // Backup format
+  boltHistory?: {
+    chats: Record<string, { messages: Message[]; description?: string }>; // Chrome extension format
+  };
+};
+
 export function ImportButtons(importChat: ((description: string, messages: Message[]) => Promise<void>) | undefined) {
   return (
     <div className="flex flex-col items-center justify-center w-auto">
@@ -20,14 +29,34 @@ export function ImportButtons(importChat: ((description: string, messages: Messa
               reader.onload = async (e) => {
                 try {
                   const content = e.target?.result as string;
-                  const data = JSON.parse(content);
+                  const data = JSON.parse(content) as ChatData;
 
-                  if (!Array.isArray(data.messages)) {
-                    toast.error('Invalid chat file format');
+                  // Standard format
+                  if (Array.isArray(data.messages)) {
+                    await importChat(data.description || 'Imported Chat', data.messages);
+                    toast.success('Chat imported successfully');
+                    return;
                   }
 
-                  await importChat(data.description, data.messages);
-                  toast.success('Chat imported successfully');
+                  // Backup format
+                  if (data.history?.[0]?.messages) {
+                    const chat = data.history[0];
+                    await importChat(chat.description || 'Imported Chat', chat.messages);
+                    toast.success('Chat imported successfully');
+                    return;
+                  }
+
+                  // Chrome format
+                  if (data.boltHistory?.chats) {
+                    const chat = Object.values(data.boltHistory.chats)[0];
+                    if (chat?.messages) {
+                      await importChat(chat.description || 'Imported Chat', chat.messages);
+                      toast.success('Chat imported successfully');
+                      return;
+                    }
+                  }
+
+                  toast.error('Invalid chat file format');
                 } catch (error: unknown) {
                   if (error instanceof Error) {
                     toast.error('Failed to parse chat file: ' + error.message);

--- a/app/components/settings/data/DataTab.tsx
+++ b/app/components/settings/data/DataTab.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import { useNavigate } from '@remix-run/react';
 import Cookies from 'js-cookie';
 import { toast } from 'react-toastify';
-import { db, deleteById, getAll } from '~/lib/persistence';
+import { db, deleteById, getAll, setMessages } from '~/lib/persistence';
 import { logStore } from '~/lib/stores/logs';
 import { classNames } from '~/utils/classNames';
+import type { Message } from 'ai';
 
 // List of supported providers that can have API keys
 const API_KEY_PROVIDERS = [
@@ -231,6 +232,116 @@ export default function DataTab() {
     event.target.value = '';
   };
 
+  const handleImportChats = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+
+    const processChatData = (data: any): Array<{
+      id: string;
+      messages: Message[];
+      description: string;
+      urlId?: string;
+    }> => {
+      // Add logging to debug format detection
+      console.log('Processing data:', {
+        hasMessages: !!data.messages,
+        isMessagesArray: Array.isArray(data.messages),
+        hasBoltHistory: !!data.boltHistory,
+        hasHistory: !!data.history,
+        hasChats: !!data.chats,
+        keys: Object.keys(data)
+      });
+
+      // Handle Bolt standard format (single chat)
+      if (data.messages && Array.isArray(data.messages)) {
+        console.log('Importing single chat:', {
+          messages: data.messages.length,
+          description: data.description
+        });
+
+        // Generate both id and urlId for single chat
+        const chatId = crypto.randomUUID();
+        return [{
+          id: chatId,
+          messages: data.messages,
+          description: data.description || 'Imported Chat',
+          urlId: chatId  // Add urlId for proper navigation
+        }];
+      }
+
+      // Handle Chrome extension format
+      if (data.boltHistory?.chats) {
+        return Object.values(data.boltHistory.chats).map((chat: any) => ({
+          id: chat.id || crypto.randomUUID(),
+          messages: chat.messages,
+          description: chat.description || 'Imported Chat',
+          urlId: chat.urlId
+        }));
+      }
+
+      // Handle history array format
+      if (data.history && Array.isArray(data.history)) {
+        return data.history.map((chat: any) => ({
+          id: chat.id || crypto.randomUUID(),
+          messages: chat.messages,
+          description: chat.description || 'Imported Chat',
+          urlId: chat.urlId
+        }));
+      }
+
+      // Handle Bolt export format (multiple chats)
+      if (data.chats && Array.isArray(data.chats)) {
+        return data.chats.map((chat: {
+          id?: string;
+          messages: Message[];
+          description?: string;
+          urlId?: string;
+        }) => ({
+          id: chat.id || crypto.randomUUID(),
+          messages: chat.messages,
+          description: chat.description || 'Imported Chat',
+          urlId: chat.urlId
+        }));
+      }
+
+      console.error('No matching format found for:', data);
+      throw new Error('Unsupported chat format');
+    };
+
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file || !db) {
+        toast.error('Something went wrong');
+        return;
+      }
+
+      try {
+        const content = await file.text();
+        const data = JSON.parse(content);
+        const chatsToImport = processChatData(data);
+
+        for (const chat of chatsToImport) {
+          await setMessages(db, chat.id, chat.messages, chat.urlId, chat.description);
+        }
+
+        logStore.logSystem('Chats imported successfully', { count: chatsToImport.length });
+        toast.success(`Successfully imported ${chatsToImport.length} chat${chatsToImport.length > 1 ? 's' : ''}`);
+        window.location.reload();
+      } catch (error) {
+        if (error instanceof Error) {
+          logStore.logError('Failed to import chats', error);
+          toast.error('Failed to import chats: ' + error.message);
+        } else {
+          toast.error('Failed to import chats');
+        }
+        console.error(error);
+      }
+    };
+
+    input.click();
+  };
+
   return (
     <div className="p-4 bg-bolt-elements-bg-depth-2 border border-bolt-elements-borderColor rounded-lg mb-4">
       <div className="mb-6">
@@ -246,6 +357,12 @@ export default function DataTab() {
                   className="px-4 py-2 bg-bolt-elements-button-primary-background hover:bg-bolt-elements-button-primary-backgroundHover text-bolt-elements-textPrimary rounded-lg transition-colors"
                 >
                   Export All Chats
+                </button>
+                <button
+                  onClick={handleImportChats}
+                  className="px-4 py-2 bg-bolt-elements-button-primary-background hover:bg-bolt-elements-button-primary-backgroundHover text-bolt-elements-textPrimary rounded-lg transition-colors"
+                >
+                  Import Chats
                 </button>
                 <button
                   onClick={handleDeleteAllChats}


### PR DESCRIPTION
This PR enhances the chat import functionality, continuing the work from #280 and #871. Care has has been taken to follow the latest structure.

Changes:
- Added Import Chats button to Data Management tab in the Settings (removed my original implementation in the sidemenu to avoid duplicate places to perform the task, we can bring it back if necessary)
- Added support for multiple chat import formats in both the main page import for single chat import as well as all chat import in the settings, following the existing method of implementation in the main window.
- Added proper error handling and logging
- Updated README

Note: This addresses feedback from previous PRs:
1. Fixed TypeScript issues
2. Improved error handling
3. Added proper success messages
4. Moved import button to Data Management tab per @wonderwhy-er's suggestion

References:
- #280 (original PR)
- #871 (continuation PR)
Overall History:
#280  Added chat history backup and restore functionality in the side bar, however the there was a structural change to bolt.diy, hand multiple conflicts with new structure. 
#871 tried to add the feature back but some of the functionality was moved and based on feedback, needed more work. 

This PR: Addressed previous feedback, merged using feature branch avoiding the issues caused in the previous PR by merging the main branch.  

Import Multiple Chats in the Settings Window:
![image](https://github.com/user-attachments/assets/4572a88f-2851-4922-9118-4a80c2ff42e1)

Import Single Chat In Main Window:
![image](https://github.com/user-attachments/assets/936b9596-b519-4b2b-b83e-d38ca2d9c60a)


_My original Method of implementation in the Side Menu removed for now since we will already have this inside the settings:_
![image](https://github.com/user-attachments/assets/f700b0ae-6fc5-40a3-92a7-9e28d75beb14)

