### PR TITLE
fix: import folder filtering

### DIFF
--- a/app/components/chat/ImportFolderButton.tsx
+++ b/app/components/chat/ImportFolderButton.tsx
@@ -16,35 +16,40 @@ export const ImportFolderButton: React.FC<ImportFolderButtonProps> = ({ classNam
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const allFiles = Array.from(e.target.files || []);
 
-    if (allFiles.length > MAX_FILES) {
-      const error = new Error(`Too many files: ${allFiles.length}`);
+    const filteredFiles = allFiles.filter((file) => {
+      const path = file.webkitRelativePath.split('/').slice(1).join('/');
+      const include = shouldIncludeFile(path);
+
+      return include;
+    });
+
+    if (filteredFiles.length === 0) {
+      const error = new Error('No valid files found');
+      logStore.logError('File import failed - no valid files', error, { folderName: 'Unknown Folder' });
+      toast.error('No files found in the selected folder');
+
+      return;
+    }
+
+    if (filteredFiles.length > MAX_FILES) {
+      const error = new Error(`Too many files: ${filteredFiles.length}`);
       logStore.logError('File import failed - too many files', error, {
-        fileCount: allFiles.length,
+        fileCount: filteredFiles.length,
         maxFiles: MAX_FILES,
       });
       toast.error(
-        `This folder contains ${allFiles.length.toLocaleString()} files. This product is not yet optimized for very large projects. Please select a folder with fewer than ${MAX_FILES.toLocaleString()} files.`,
+        `This folder contains ${filteredFiles.length.toLocaleString()} files. This product is not yet optimized for very large projects. Please select a folder with fewer than ${MAX_FILES.toLocaleString()} files.`,
       );
 
       return;
     }
 
-    const folderName = allFiles[0]?.webkitRelativePath.split('/')[0] || 'Unknown Folder';
+    const folderName = filteredFiles[0]?.webkitRelativePath.split('/')[0] || 'Unknown Folder';
     setIsLoading(true);
 
     const loadingToast = toast.loading(`Importing ${folderName}...`);
 
     try {
-      const filteredFiles = allFiles.filter((file) => shouldIncludeFile(file.webkitRelativePath));
-
-      if (filteredFiles.length === 0) {
-        const error = new Error('No valid files found');
-        logStore.logError('File import failed - no valid files', error, { folderName });
-        toast.error('No files found in the selected folder');
-
-        return;
-      }
-
       const fileChecks = await Promise.all(
         filteredFiles.map(async (file) => ({
           file,


### PR DESCRIPTION
Hello,

I was trying to play around with some repos from projects I don't host in github. So I tried using the Import folder button and noticed It was loading files from folders that should be ignored so I took a little time to check and saw the function was almost there just needed to be moved.

Also the removed the folder name before sending to shouldIncludeFile so the IGNORE_PATTERNS wroked.
