### PR TITLE
fix: refresh model list after api key changes

### DIFF
--- a/app/components/chat/APIKeyManager.tsx
+++ b/app/components/chat/APIKeyManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { IconButton } from '~/components/ui/IconButton';
 import type { ProviderInfo } from '~/types/model';
+import Cookies from 'js-cookie';
 
 interface APIKeyManagerProps {
   provider: ProviderInfo;
@@ -8,6 +9,23 @@ interface APIKeyManagerProps {
   setApiKey: (key: string) => void;
   getApiKeyLink?: string;
   labelForGetApiKey?: string;
+}
+
+const apiKeyMemoizeCache: { [k: string]: Record<string, string> } = {};
+
+export function getApiKeysFromCookies() {
+  const storedApiKeys = Cookies.get('apiKeys');
+  let parsedKeys = {};
+
+  if (storedApiKeys) {
+    parsedKeys = apiKeyMemoizeCache[storedApiKeys];
+
+    if (!parsedKeys) {
+      parsedKeys = apiKeyMemoizeCache[storedApiKeys] = JSON.parse(storedApiKeys);
+    }
+  }
+
+  return parsedKeys;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
Reason for change:
Came up here https://github.com/stackblitz-labs/bolt.diy/pull/943
When provider has dynamic provider list that requires API key its not refreshed when you set a key
Here I made mode list refresh when keys are set

What was done:
- I separated model initialisation in to its own useEffect with apiKeys as dependency, so when they change its refreshed
- That was not enough as way we get keys always creates new object even if its the same, so use effect running in a loop
- I fixed above by making "memoizing" function that gets api keys from cookies, so if api keys did not change its same object and useEffect is not run