### PR TITLE
fix: artifacts content indentation

### DIFF
--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -101,7 +101,28 @@ export class StreamingMessageParser {
           const currentAction = state.currentAction;
 
           if (closeIndex !== -1) {
-            currentAction.content += input.slice(i, closeIndex);
+            const contentWithIndentation = input.slice(i, closeIndex);
+
+            const cleanCodeContent = (content: string) => {
+              const lines = content.split('\n');
+
+              const minIndent = lines.reduce((min, line) => {
+                if (line.trim() === '') {
+                  return min;
+                }
+
+                const leadingSpaces = (line.match(/^\s*/) || [''])[0].length;
+
+                return Math.min(min, leadingSpaces);
+              }, Infinity);
+
+              return lines
+                .map((line) => line.slice(minIndent))
+                .join('\n')
+                .trim();
+            };
+
+            currentAction.content += cleanCodeContent(contentWithIndentation);
 
             let content = currentAction.content.trim();
 


### PR DESCRIPTION
This fixes an issue with indentation of the files content.

It works with python, etc  

this is an example of how indentation is broken
<img width="633" alt="image" src="https://github.com/user-attachments/assets/51dc075f-7837-44dc-a20e-a269c9f4fd03" />

this is how it gets fixed
<img width="664" alt="Captura de pantalla 2024-12-30 a la(s) 5 32 23 p m" src="https://github.com/user-attachments/assets/42780926-979a-4115-b60d-699e948f569e" />


