### PR TITLE
fix: show warning on starter template failure and continue

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -297,7 +297,15 @@ export const ChatImpl = memo(
         });
 
         if (template !== 'blank') {
-          const temResp = await getTemplates(template, title);
+          const temResp = await getTemplates(template, title).catch((e) => {
+            if (e.message.includes('rate limit')) {
+              toast.warning('Rate limit exceeded. Skipping starter template\n Continuing with blank template');
+            } else {
+              toast.warning('Failed to import starter template\n Continuing with blank template');
+            }
+
+            return null;
+          });
 
           if (temResp) {
             const { assistantMessage, userMessage } = temResp;


### PR DESCRIPTION
handled error during starter template pull, and continue with blank template on failure 

