### PR TITLE
fix: ollama and lm studio url issue fix for docker and build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,14 @@ ENV WRANGLER_SEND_METRICS=false \
     TOGETHER_API_KEY=${TOGETHER_API_KEY} \
     TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL} \
     VITE_LOG_LEVEL=${VITE_LOG_LEVEL} \
-    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}
+    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}\
+    RUNNING_IN_DOCKER=true
 
 # Pre-configure wrangler to disable metrics
 RUN mkdir -p /root/.config/.wrangler && \
     echo '{"enabled":false}' > /root/.config/.wrangler/metrics.json
 
-RUN npm run build
+RUN pnpm run build
 
 CMD [ "pnpm", "run", "dockerstart"]
 
@@ -77,7 +78,8 @@ ENV GROQ_API_KEY=${GROQ_API_KEY} \
     TOGETHER_API_KEY=${TOGETHER_API_KEY} \
     TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL} \
     VITE_LOG_LEVEL=${VITE_LOG_LEVEL} \
-    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}
+    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}\
+    RUNNING_IN_DOCKER=true
 
 RUN mkdir -p ${WORKDIR}/run
 CMD pnpm run dev --host

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,14 +26,14 @@ export default defineConfig((config) => {
     define: {
       __COMMIT_HASH: JSON.stringify(getGitHash()),
       __APP_VERSION: JSON.stringify(process.env.npm_package_version),
-      'process.env': JSON.stringify(process.env)
+      // 'process.env': JSON.stringify(process.env)
     },
     build: {
       target: 'esnext',
     },
     plugins: [
       nodePolyfills({
-        include: ['path', 'buffer'],
+        include: ['path', 'buffer', 'process'],
       }),
       config.mode !== 'test' && remixCloudflareDevProxy(),
       remixVitePlugin({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,10 @@ import { defineConfig, type ViteDevServer } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { optimizeCssModules } from 'vite-plugin-optimize-css-modules';
 import tsconfigPaths from 'vite-tsconfig-paths';
-
+import * as dotenv from 'dotenv';
 import { execSync } from 'child_process';
+
+dotenv.config();
 
 // Get git hash with fallback
 const getGitHash = () => {
@@ -17,11 +19,14 @@ const getGitHash = () => {
 };
 
 
+
+
 export default defineConfig((config) => {
   return {
     define: {
       __COMMIT_HASH: JSON.stringify(getGitHash()),
       __APP_VERSION: JSON.stringify(process.env.npm_package_version),
+      'process.env': JSON.stringify(process.env)
     },
     build: {
       target: 'esnext',


### PR DESCRIPTION
# Docker Host URL Resolution Fix for LMStudio and Ollama Providers

## Overview
This PR addresses connectivity issues between the application running in Docker containers and local LLM providers (LMStudio and Ollama). It implements proper host URL resolution by replacing localhost/127.0.0.1 with host.docker.internal when running in a Docker environment.

## Key Changes
### 1. Docker Environment Detection
- Added `RUNNING_IN_DOCKER=true` environment variable to Dockerfile configurations
- Implemented detection logic in provider classes to handle URL transformation

### 2. Provider Base URL Resolution
- Enhanced URL handling in LMStudio and Ollama providers
- Added proper error handling for missing base URLs
- Implemented consistent URL transformation for Docker environments

### 3. Provider Settings Access Fix
- Fixed provider settings access by correctly referencing provider-specific settings using `providerSettings?.[this.name]`
- Ensures proper configuration loading for each provider instance

## Technical Details
### Provider Settings Fix
Fixed provider configuration initialization with proper settings access and defaults:

```typescript
let { baseUrl } = this.getProviderBaseUrlAndKey({
  apiKeys,
  providerSettings: providerSettings?.[this.name],
  serverEnv: serverEnv as any,
  defaultBaseUrlKey: 'OLLAMA_API_BASE_URL',
  defaultApiTokenKey: '',
});
```

This change:
- Correctly accesses provider-specific settings using `providerSettings?.[this.name]`

### URL Resolution Implementation
Key changes in the provider classes:

```typescript
// LMStudio and Ollama Provider URL Resolution
if (typeof window === 'undefined') {
  /*
   * Running in Server
   * Backend: Check if we're running in Docker
   */
  const isDocker = process.env.RUNNING_IN_DOCKER === 'true';

  baseUrl = isDocker ? baseUrl.replace('localhost', 'host.docker.internal') : baseUrl;
  baseUrl = isDocker ? baseUrl.replace('127.0.0.1', 'host.docker.internal') : baseUrl;
}
```

### System Changes
- Added environment variable `RUNNING_IN_DOCKER` in both development and production Dockerfile configurations
- Enhanced error handling for missing base URLs in provider configurations
- Added debug logging for base URL resolution in both providers
- Updated provider configuration to properly handle server-side URL transformation

## Testing
- Verified connectivity between Docker container and local LLM providers
- Tested URL resolution in both Docker and non-Docker environments
- Validated error handling for missing base URLs
- Confirmed proper functioning of both LMStudio and Ollama providers

## Migration Impact
- No breaking changes to existing functionality
- Added environment variable `RUNNING_IN_DOCKER` needs to be set in Docker environments
- Existing Docker deployments will need to rebuild their containers
