### PR TITLE
ci: docker Image creation pipeline

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ on:
       - "*"
 
 env:
-  DOCKER_REPO: ghcr.io
+  REGISTRY: ghcr.io
   DOCKER_IMAGE: ghcr.io/${{ github.repository }}
   BUILD_TARGET: bolt-ai-production # bolt-ai-development
 
@@ -51,9 +51,9 @@ jobs:
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKER_REPO }}
-          username: ${{ github.repository_owner }} # ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.CR_PAT }} # ${{ secrets.DOCKER_PASSWORD }} 
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }} # ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }} # ${{ secrets.DOCKER_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,74 @@
+---
+name: Docker Publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+      - "*"
+
+env:
+  DOCKER_REPO: ghcr.io
+  DOCKER_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  docker-build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: string
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.DOCKER_IMAGE }}
+
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v5
+        with:
+          images: ${{ steps.string.outputs.lowercase }}
+          flavor: |
+            latest=true
+            prefix=
+            suffix=
+          tags: |
+            type=semver,pattern={{version}}
+            type=pep440,pattern={{version}}
+            type=ref,event=tag
+            type=raw,value={{sha}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REPO }}
+          username: ${{ github.repository_owner }} # ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.CR_PAT }} # ${{ secrets.DOCKER_PASSWORD }} 
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ steps.string.outputs.lowercase }}:latest
+          cache-to: type=inline
+
+      - name: Check manifest
+        run: |
+          docker buildx imagetools inspect ${{ steps.string.outputs.lowercase }}:${{ steps.meta.outputs.version }}
+
+      - name: Dump context
+        if: always()
+        uses: crazy-max/ghaction-dump-context@v2

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,6 +13,7 @@ on:
 env:
   DOCKER_REPO: ghcr.io
   DOCKER_IMAGE: ghcr.io/${{ github.repository }}
+  BUILD_TARGET: bolt-ai-production # bolt-ai-development
 
 jobs:
   docker-build-publish:
@@ -59,7 +60,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          target: bolt-ai-production
+          target: ${{ env.BUILD_TARGET }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,6 +59,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          target: bolt-ai-production
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Created a basic container image creation pipeline.

Fix #946

Note:
You need to set a personal access token with the package permission in the secrets to publish to the github container registry.
For publishing to docker hub, you need to update the urls as well as the credentials.
