### PR TITLE
fix: Send file modifications diff to llm

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -23,6 +23,7 @@ import type { ProviderInfo } from '~/types/model';
 import { useSearchParams } from '@remix-run/react';
 import { createSampler } from '~/utils/sampler';
 import { getTemplates, selectStarterTemplate } from '~/utils/selectStarterTemplate';
+import { fileModificationsToHTML } from '~/utils/diff';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -382,6 +383,7 @@ export const ChatImpl = memo(
       }
 
       if (fileModifications !== undefined) {
+        const diff = fileModificationsToHTML(fileModifications);
         /**
          * If we have file modifications we append a new user message manually since we have to prefix
          * the user input with the file modifications and we don't want the new user input to appear
@@ -394,7 +396,7 @@ export const ChatImpl = memo(
           content: [
             {
               type: 'text',
-              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${_input}`,
+              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${diff}\n\n${_input}`,
             },
             ...imageDataList.map((imageData) => ({
               type: 'image',


### PR DESCRIPTION
Currently the file modifications by user, does not reflect on the conversation with LLM. You can test this by making a change and then asking the model "What change did I just make?"

This functionality was initially there in commit 6e8aa04d, but was somehow overwritten in commit 7cdb56a8.

This PR adds back that feature.