### PR TITLE
Fix file modifications no longer being sent to LLM

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -23,6 +23,7 @@ import type { ProviderInfo } from '~/types/model';
 import { useSearchParams } from '@remix-run/react';
 import { createSampler } from '~/utils/sampler';
 import { getTemplates, selectStarterTemplate } from '~/utils/selectStarterTemplate';
+import { fileModificationsToHTML } from '~/utils/diff';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -382,6 +383,8 @@ export const ChatImpl = memo(
       }
 
       if (fileModifications !== undefined) {
+        const diff = fileModificationsToHTML(fileModifications);
+
         /**
          * If we have file modifications we append a new user message manually since we have to prefix
          * the user input with the file modifications and we don't want the new user input to appear
@@ -394,7 +397,7 @@ export const ChatImpl = memo(
           content: [
             {
               type: 'text',
-              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${_input}`,
+              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${diff}\n\n${_input}`,
             },
             ...imageDataList.map((imageData) => ({
               type: 'image',

--- a/app/components/chat/UserMessage.tsx
+++ b/app/components/chat/UserMessage.tsx
@@ -4,6 +4,7 @@
  */
 import { MODEL_REGEX, PROVIDER_REGEX } from '~/utils/constants';
 import { Markdown } from './Markdown';
+import { modificationsRegex } from '~/utils/diff';
 
 interface UserMessageProps {
   content: string | Array<{ type: string; text?: string; image?: string }>;
@@ -43,5 +44,5 @@ export function UserMessage({ content }: UserMessageProps) {
 }
 
 function stripMetadata(content: string) {
-  return content.replace(MODEL_REGEX, '').replace(PROVIDER_REGEX, '');
+  return content.replace(modificationsRegex, '').replace(MODEL_REGEX, '').replace(PROVIDER_REGEX, '');
 }

--- a/app/utils/diff.ts
+++ b/app/utils/diff.ts
@@ -3,8 +3,8 @@ import type { FileMap } from '~/lib/stores/files';
 import { MODIFICATIONS_TAG_NAME, WORK_DIR } from './constants';
 
 export const modificationsRegex = new RegExp(
-  `^<${MODIFICATIONS_TAG_NAME}>[\\s\\S]*?<\\/${MODIFICATIONS_TAG_NAME}>\\s+`,
-  'g',
+  `^<${MODIFICATIONS_TAG_NAME}>[\\s\\S]*<\\/${MODIFICATIONS_TAG_NAME}>\\s+`,
+  'gm',
 );
 
 interface ModifiedFile {


### PR DESCRIPTION
- Feature first introduced [here](https://github.com/stackblitz-labs/bolt.diy/commit/2cb3f099#diff-3dbaf0b70d2fce87f911ab2a9dcbc158713bfe05f3850c10f2b83ffed38570bbR125)
- The call to fileModificationsToHTML (responsible for sending file modifications to the LLM) was lost in the merge [here](https://github.com/stackblitz-labs/bolt.diy/commit/7cdb56a#diff-c3e814ea52016b5a6aa549d4a1b89d306c9ac276ba0f79a956dba166e6c84b09L193)
- Modifications sanitization (responsible for hiding metadata in the chat UI) was commented out [here](https://github.com/stackblitz-labs/bolt.diy/commit/e78a5b0a050818454344020b1682c07c1051f932#diff-dd246a18ac09a3e1a293988bf2f81b4f246f4c4aa03db23db48f79371c378981R25)
- The function sanitizeUserMessage was renamed to stripMetadata [here](https://github.com/stackblitz-labs/bolt.diy/commit/225b55387669c9216f60896514e762515b8b1838#diff-dd246a18ac09a3e1a293988bf2f81b4f246f4c4aa03db23db48f79371c378981R36)

This PR also updates the regex to actually match against the current file diff output

Should address #752 and perhaps #921