### PR TITLE
fix: cors issues from preview fixed by changing embedder policies 

### DIFF
--- a/app/components/chat/chatExportAndImport/ImportButtons.tsx
+++ b/app/components/chat/chatExportAndImport/ImportButtons.tsx
@@ -31,6 +31,7 @@ export function ImportButtons(importChat: ((description: string, messages: Messa
                   if (Array.isArray(data.messages)) {
                     await importChat(data.description || 'Imported Chat', data.messages);
                     toast.success('Chat imported successfully');
+
                     return;
                   }
 

--- a/app/components/settings/data/DataTab.tsx
+++ b/app/components/settings/data/DataTab.tsx
@@ -233,7 +233,9 @@ export default function DataTab() {
     event.target.value = '';
   };
 
-  const processChatData = (data: any): Array<{
+  const processChatData = (
+    data: any,
+  ): Array<{
     id: string;
     messages: Message[];
     description: string;
@@ -242,23 +244,25 @@ export default function DataTab() {
     // Handle Bolt standard format (single chat)
     if (data.messages && Array.isArray(data.messages)) {
       const chatId = crypto.randomUUID();
-      return [{
-        id: chatId,
-        messages: data.messages,
-        description: data.description || 'Imported Chat',
-        urlId: chatId
-      }];
+      return [
+        {
+          id: chatId,
+          messages: data.messages,
+          description: data.description || 'Imported Chat',
+          urlId: chatId,
+        },
+      ];
     }
 
-      // Handle Bolt export format (multiple chats)
-      if (data.chats && Array.isArray(data.chats)) {
-        return data.chats.map((chat: { id?: string; messages: Message[]; description?: string; urlId?: string; }) => ({
-          id: chat.id || crypto.randomUUID(),
-          messages: chat.messages,
-          description: chat.description || 'Imported Chat',
-          urlId: chat.urlId,
-        }));
-      }
+    // Handle Bolt export format (multiple chats)
+    if (data.chats && Array.isArray(data.chats)) {
+      return data.chats.map((chat: { id?: string; messages: Message[]; description?: string; urlId?: string }) => ({
+        id: chat.id || crypto.randomUUID(),
+        messages: chat.messages,
+        description: chat.description || 'Imported Chat',
+        urlId: chat.urlId,
+      }));
+    }
 
     console.error('No matching format found for:', data);
     throw new Error('Unsupported chat format');
@@ -296,6 +300,7 @@ export default function DataTab() {
         } else {
           toast.error('Failed to import chats');
         }
+
         console.error(error);
       }
     };

--- a/app/lib/webcontainer/index.ts
+++ b/app/lib/webcontainer/index.ts
@@ -24,6 +24,7 @@ if (!import.meta.env.SSR) {
     Promise.resolve()
       .then(() => {
         return WebContainer.boot({
+          coep: 'credentialless',
           workdirName: WORK_DIR_NAME,
           forwardPreviewErrors: true, // Enable error forwarding from iframes
         });


### PR DESCRIPTION
## **Reason for Change**

Issue reported here:  
[https://thinktank.ottomator.ai/t/cors-proxy-needed/4096/6](https://thinktank.ottomator.ai/t/cors-proxy-needed/4096/6)

`leex279` shared an example of OpenStreetMap.  
I tested that it works in `bolt.new` but not in `DIY`.

### **Difference Identified**

The issue was traced to the **Cross-Origin Embedder Policy (COEP):**

1. **DIY (hosted from `local-corp.webcontainer-api.io`)**
   - **Header:** `cross-origin-embedder-policy: require-corp`
   - **Impact:**  
     This policy mandates that all resources loaded by the iframe must explicitly allow cross-origin embedding by setting appropriate headers (e.g., `Cross-Origin-Resource-Policy` or `Access-Control-Allow-Origin`).  
     If the tile server (`a.tile.openstreetmap.org`) doesn't fully comply with this policy, the browser blocks the resource.

2. **Bolt.New (hosted from `local-credentialless.webcontainer-api.io`)**
   - **Header:** `cross-origin-embedder-policy: credentialless`
   - **Impact:**  
     This policy is less restrictive and doesn't require the same level of resource permissions. It works better with services like OpenStreetMap that rely on permissive `Access-Control-Allow-Origin: *`.

---

### **Solution**

I explored the differences and found two places where this policy could be changed.  
After making these changes, it works correctly.

---

### **Before**
<img width="1698" alt="image" src="https://github.com/user-attachments/assets/7442dc89-72b2-4040-8e2f-bb29fa3afee9" />


---

### **After**
<img width="1701" alt="Screenshot 2025-01-09 at 10 44 35" src="https://github.com/user-attachments/assets/5737aa07-7a40-49c7-8298-4abf65c404ca" />

