### PR TITLE
fix: bugfix in fetching API Key on base llm provider

### DIFF
--- a/app/lib/modules/llm/base-provider.ts
+++ b/app/lib/modules/llm/base-provider.ts
@@ -46,7 +46,7 @@ export abstract class BaseProvider implements ProviderInfo {
 
     const apiTokenKey = this.config.apiTokenKey || defaultApiTokenKey;
     const apiKey =
-      apiKeys?.[this.name] || serverEnv?.[apiTokenKey] || process?.env?.[apiTokenKey] || manager.env?.[baseUrlKey];
+      apiKeys?.[this.name] || serverEnv?.[apiTokenKey] || process?.env?.[apiTokenKey] || manager.env?.[apiTokenKey];
 
     return {
       baseUrl,


### PR DESCRIPTION
Found a bug in the OpenAILike provider. It fetches the API Key as the base URL. Simple one line change.