### PR TITLE
fix: use correctly chosen model for streaming, in cases of fallback

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -228,7 +228,7 @@ export async function streamText(props: {
 
   return await _streamText({
     model: provider.getModelInstance({
-      model: currentModel,
+      model: modelDetails.name,
       serverEnv,
       apiKeys,
       providerSettings,


### PR DESCRIPTION
Without this, it will try to use the `DEFAULT_MODEL` of `claude-3-5-sonnet-latest`