### PR TITLE
feat: configure dynamic providers via .env

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -158,7 +158,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
         }
 
         setIsModelLoading('all');
-        fetch(`/api/models?apiKeys=${encodeURIComponent(JSON.stringify(parsedApiKeys))}`)
+        fetch('/api/models', {
+          headers: {
+            'x-client-api-keys': JSON.stringify(parsedApiKeys),
+          },
+        })
           .then((response) => response.json())
           .then((data) => {
             const typedData = data as { modelList: ModelInfo[] };
@@ -181,7 +185,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       setIsModelLoading(providerName);
 
       try {
-        const response = await fetch(`/api/models?apiKeys=${encodeURIComponent(JSON.stringify(newApiKeys))}`);
+        const response = await fetch('/api/models', {
+          headers: {
+            'x-client-api-keys': JSON.stringify(newApiKeys),
+          },
+        });
         const data = await response.json();
         const typedData = data as { modelList: ModelInfo[] };
         setModelList(typedData.modelList);

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -212,7 +212,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       try {
         const providerSettings = getProviderSettings();
 
-        const response = await fetch('/api/models', {
+        const response = await fetch(`/api/models/${encodeURIComponent(providerName)}`, {
           headers: {
             'x-client-api-keys': JSON.stringify(newApiKeys),
             'x-client-provider-settings': JSON.stringify(providerSettings),
@@ -220,7 +220,12 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
         });
         const data = await response.json();
         const typedData = data as { modelList: ModelInfo[] };
-        setModelList(typedData.modelList);
+
+        // Only update models for the specific provider
+        setModelList((prevModels) => {
+          const otherModels = prevModels.filter((model) => model.provider !== providerName);
+          return [...otherModels, ...typedData.modelList];
+        });
       } catch (error) {
         console.error('Error loading dynamic models:', error);
       }

--- a/app/lib/api/cookies.ts
+++ b/app/lib/api/cookies.ts
@@ -1,0 +1,33 @@
+export function parseCookies(cookieHeader: string | null) {
+  const cookies: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  // Split the cookie string by semicolons and spaces
+  const items = cookieHeader.split(';').map((cookie) => cookie.trim());
+
+  items.forEach((item) => {
+    const [name, ...rest] = item.split('=');
+
+    if (name && rest.length > 0) {
+      // Decode the name and value, and join value parts in case it contains '='
+      const decodedName = decodeURIComponent(name.trim());
+      const decodedValue = decodeURIComponent(rest.join('=').trim());
+      cookies[decodedName] = decodedValue;
+    }
+  });
+
+  return cookies;
+}
+
+export function getApiKeysFromCookie(cookieHeader: string | null): Record<string, string> {
+  const cookies = parseCookies(cookieHeader);
+  return cookies.apiKeys ? JSON.parse(cookies.apiKeys) : {};
+}
+
+export function getProviderSettingsFromCookie(cookieHeader: string | null): Record<string, any> {
+  const cookies = parseCookies(cookieHeader);
+  return cookies.providers ? JSON.parse(cookies.providers) : {};
+}

--- a/app/lib/hooks/useModels.ts
+++ b/app/lib/hooks/useModels.ts
@@ -1,7 +1,0 @@
-import { useLoaderData } from '@remix-run/react';
-import type { ModelInfo } from '~/lib/modules/llm/types';
-
-export function useModels() {
-  const { modelList } = useLoaderData<{ modelList: ModelInfo[] }>();
-  return modelList;
-}

--- a/app/lib/hooks/useModels.ts
+++ b/app/lib/hooks/useModels.ts
@@ -1,0 +1,7 @@
+import { useLoaderData } from '@remix-run/react';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+
+export function useModels() {
+  const { modelList } = useLoaderData<{ modelList: ModelInfo[] }>();
+  return modelList;
+}

--- a/app/lib/modules/llm/manager.ts
+++ b/app/lib/modules/llm/manager.ts
@@ -83,7 +83,7 @@ export class LLMManager {
 
     let enabledProviders = Array.from(this._providers.values()).map((p) => p.name);
 
-    if (providerSettings) {
+    if (providerSettings && Object.keys(providerSettings).length > 0) {
       enabledProviders = enabledProviders.filter((p) => providerSettings[p].enabled);
     }
 

--- a/app/routes/api.enhancer.ts
+++ b/app/routes/api.enhancer.ts
@@ -1,32 +1,11 @@
 import { type ActionFunctionArgs } from '@remix-run/cloudflare';
-
-//import { StreamingTextResponse, parseStreamPart } from 'ai';
 import { streamText } from '~/lib/.server/llm/stream-text';
 import { stripIndents } from '~/utils/stripIndent';
-import type { IProviderSetting, ProviderInfo } from '~/types/model';
+import type { ProviderInfo } from '~/types/model';
+import { getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
 
 export async function action(args: ActionFunctionArgs) {
   return enhancerAction(args);
-}
-
-function parseCookies(cookieHeader: string) {
-  const cookies: any = {};
-
-  // Split the cookie string by semicolons and spaces
-  const items = cookieHeader.split(';').map((cookie) => cookie.trim());
-
-  items.forEach((item) => {
-    const [name, ...rest] = item.split('=');
-
-    if (name && rest) {
-      // Decode the name and value, and join value parts in case it contains '='
-      const decodedName = decodeURIComponent(name.trim());
-      const decodedValue = decodeURIComponent(rest.join('=').trim());
-      cookies[decodedName] = decodedValue;
-    }
-  });
-
-  return cookies;
 }
 
 async function enhancerAction({ context, request }: ActionFunctionArgs) {
@@ -55,12 +34,8 @@ async function enhancerAction({ context, request }: ActionFunctionArgs) {
   }
 
   const cookieHeader = request.headers.get('Cookie');
-
-  // Parse the cookie's value (returns an object or null if no cookie exists)
-  const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
-  const providerSettings: Record<string, IProviderSetting> = JSON.parse(
-    parseCookies(cookieHeader || '').providers || '{}',
-  );
+  const apiKeys = getApiKeysFromCookie(cookieHeader);
+  const providerSettings = getProviderSettingsFromCookie(cookieHeader);
 
   try {
     const result = await streamText({

--- a/app/routes/api.llmcall.ts
+++ b/app/routes/api.llmcall.ts
@@ -1,6 +1,4 @@
 import { type ActionFunctionArgs } from '@remix-run/cloudflare';
-
-//import { StreamingTextResponse, parseStreamPart } from 'ai';
 import { streamText } from '~/lib/.server/llm/stream-text';
 import type { IProviderSetting, ProviderInfo } from '~/types/model';
 import { generateText } from 'ai';
@@ -8,29 +6,10 @@ import { PROVIDER_LIST } from '~/utils/constants';
 import { MAX_TOKENS } from '~/lib/.server/llm/constants';
 import { LLMManager } from '~/lib/modules/llm/manager';
 import type { ModelInfo } from '~/lib/modules/llm/types';
+import { getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
 
 export async function action(args: ActionFunctionArgs) {
   return llmCallAction(args);
-}
-
-function parseCookies(cookieHeader: string) {
-  const cookies: any = {};
-
-  // Split the cookie string by semicolons and spaces
-  const items = cookieHeader.split(';').map((cookie) => cookie.trim());
-
-  items.forEach((item) => {
-    const [name, ...rest] = item.split('=');
-
-    if (name && rest) {
-      // Decode the name and value, and join value parts in case it contains '='
-      const decodedName = decodeURIComponent(name.trim());
-      const decodedValue = decodeURIComponent(rest.join('=').trim());
-      cookies[decodedName] = decodedValue;
-    }
-  });
-
-  return cookies;
 }
 
 async function getModelList(options: {
@@ -69,12 +48,8 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
   }
 
   const cookieHeader = request.headers.get('Cookie');
-
-  // Parse the cookie's value (returns an object or null if no cookie exists)
-  const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
-  const providerSettings: Record<string, IProviderSetting> = JSON.parse(
-    parseCookies(cookieHeader || '').providers || '{}',
-  );
+  const apiKeys = getApiKeysFromCookie(cookieHeader);
+  const providerSettings = getProviderSettingsFromCookie(cookieHeader);
 
   if (streamOutput) {
     try {

--- a/app/routes/api.models.$provider.ts
+++ b/app/routes/api.models.$provider.ts
@@ -1,0 +1,2 @@
+import { loader } from './api.models';
+export { loader };

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -2,6 +2,7 @@ import { json } from '@remix-run/cloudflare';
 import { LLMManager } from '~/lib/modules/llm/manager';
 import type { ModelInfo } from '~/lib/modules/llm/types';
 import type { ProviderInfo } from '~/types/model';
+import { getApiKeysFromCookie, getProviderSettingsFromCookie } from '~/lib/api/cookies';
 
 interface ModelsResponse {
   modelList: ModelInfo[];
@@ -46,12 +47,10 @@ export async function loader({
 }): Promise<Response> {
   const llmManager = LLMManager.getInstance(import.meta.env);
 
-  // process client-side overwritten api keys and provider settings
-  const clientsideApiKeys = request.headers.get('x-client-api-keys');
-  const cliensideProviderSettings = request.headers.get('x-client-provider-settings');
-
-  const apiKeys = clientsideApiKeys ? JSON.parse(clientsideApiKeys) : {};
-  const providerSettings = cliensideProviderSettings ? JSON.parse(cliensideProviderSettings) : {};
+  // Get client side maintained API keys and provider settings from cookies
+  const cookieHeader = request.headers.get('Cookie');
+  const apiKeys = getApiKeysFromCookie(cookieHeader);
+  const providerSettings = getProviderSettingsFromCookie(cookieHeader);
 
   const { providers, defaultProvider } = getProviderInfo(llmManager);
 

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -1,6 +1,43 @@
 import { json } from '@remix-run/cloudflare';
-import { MODEL_LIST } from '~/utils/constants';
+import { LLMManager } from '~/lib/modules/llm/manager';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { ProviderInfo } from '~/types/model';
 
-export async function loader() {
-  return json(MODEL_LIST);
+interface ModelsResponse {
+  modelList: ModelInfo[];
+  providers: ProviderInfo[];
+  defaultProvider: ProviderInfo;
+}
+
+export async function loader(): Promise<Response> {
+  const llmManager = LLMManager.getInstance(import.meta.env);
+
+  // Get all providers and map to ProviderInfo interface
+  const providers = llmManager.getAllProviders().map((provider) => ({
+    name: provider.name,
+    staticModels: provider.staticModels,
+    getApiKeyLink: provider.getApiKeyLink,
+    labelForGetApiKey: provider.labelForGetApiKey,
+    icon: provider.icon,
+  }));
+
+  const defaultProvider = {
+    name: llmManager.getDefaultProvider().name,
+    staticModels: llmManager.getDefaultProvider().staticModels,
+    getApiKeyLink: llmManager.getDefaultProvider().getApiKeyLink,
+    labelForGetApiKey: llmManager.getDefaultProvider().labelForGetApiKey,
+    icon: llmManager.getDefaultProvider().icon,
+  };
+
+  const modelList = await llmManager.updateModelList({
+    apiKeys: {},
+    providerSettings: {},
+    serverEnv: import.meta.env,
+  });
+
+  return json<ModelsResponse>({
+    modelList,
+    providers,
+    defaultProvider,
+  });
 }

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -11,11 +11,10 @@ interface ModelsResponse {
 
 export async function loader({ request }: { request: Request }): Promise<Response> {
   const llmManager = LLMManager.getInstance(import.meta.env);
-  const url = new URL(request.url);
 
-  // process client-side overwritten api keys
-  const apiKeysParam = url.searchParams.get('apiKeys');
-  const apiKeys = apiKeysParam ? JSON.parse(decodeURIComponent(apiKeysParam)) : {};
+  // Get API keys from header
+  const apiKeysHeader = request.headers.get('x-client-api-keys');
+  const apiKeys = apiKeysHeader ? JSON.parse(apiKeysHeader) : {};
 
   // Get all providers and map to ProviderInfo interface
   const providers = llmManager.getAllProviders().map((provider) => ({

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -9,8 +9,13 @@ interface ModelsResponse {
   defaultProvider: ProviderInfo;
 }
 
-export async function loader(): Promise<Response> {
+export async function loader({ request }: { request: Request }): Promise<Response> {
   const llmManager = LLMManager.getInstance(import.meta.env);
+  const url = new URL(request.url);
+
+  // process client-side overwritten api keys
+  const apiKeysParam = url.searchParams.get('apiKeys');
+  const apiKeys = apiKeysParam ? JSON.parse(decodeURIComponent(apiKeysParam)) : {};
 
   // Get all providers and map to ProviderInfo interface
   const providers = llmManager.getAllProviders().map((provider) => ({
@@ -30,7 +35,7 @@ export async function loader(): Promise<Response> {
   };
 
   const modelList = await llmManager.updateModelList({
-    apiKeys: {},
+    apiKeys,
     providerSettings: {},
     serverEnv: import.meta.env,
   });

--- a/app/routes/api.models.ts
+++ b/app/routes/api.models.ts
@@ -40,15 +40,18 @@ function getProviderInfo(llmManager: LLMManager) {
 export async function loader({ request }: { request: Request }): Promise<Response> {
   const llmManager = LLMManager.getInstance(import.meta.env);
 
-  // process client-side overwritten api keys
+  // process client-side overwritten api keys and provider settings
   const clientsideApiKeys = request.headers.get('x-client-api-keys');
+  const cliensideProviderSettings = request.headers.get('x-client-provider-settings');
+
   const apiKeys = clientsideApiKeys ? JSON.parse(clientsideApiKeys) : {};
+  const providerSettings = cliensideProviderSettings ? JSON.parse(cliensideProviderSettings) : [];
 
   const { providers, defaultProvider } = getProviderInfo(llmManager);
 
   const modelList = await llmManager.updateModelList({
     apiKeys,
-    providerSettings: {},
+    providerSettings,
     serverEnv: import.meta.env,
   });
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,7 +1,4 @@
-import type { IProviderSetting } from '~/types/model';
-
 import { LLMManager } from '~/lib/modules/llm/manager';
-import type { ModelInfo } from '~/lib/modules/llm/types';
 import type { Template } from '~/types/template';
 
 export const WORK_DIR_NAME = 'project';
@@ -17,43 +14,13 @@ const llmManager = LLMManager.getInstance(import.meta.env);
 export const PROVIDER_LIST = llmManager.getAllProviders();
 export const DEFAULT_PROVIDER = llmManager.getDefaultProvider();
 
-let MODEL_LIST = llmManager.getModelList();
-
-const providerBaseUrlEnvKeys: Record<string, { baseUrlKey?: string; apiTokenKey?: string }> = {};
+export const providerBaseUrlEnvKeys: Record<string, { baseUrlKey?: string; apiTokenKey?: string }> = {};
 PROVIDER_LIST.forEach((provider) => {
   providerBaseUrlEnvKeys[provider.name] = {
     baseUrlKey: provider.config.baseUrlKey,
     apiTokenKey: provider.config.apiTokenKey,
   };
 });
-
-// Export the getModelList function using the manager
-export async function getModelList(options: {
-  apiKeys?: Record<string, string>;
-  providerSettings?: Record<string, IProviderSetting>;
-  serverEnv?: Record<string, string>;
-}) {
-  return await llmManager.updateModelList(options);
-}
-
-async function initializeModelList(options: {
-  env?: Record<string, string>;
-  providerSettings?: Record<string, IProviderSetting>;
-  apiKeys?: Record<string, string>;
-}): Promise<ModelInfo[]> {
-  const { providerSettings, apiKeys, env } = options;
-  const list = await getModelList({
-    apiKeys,
-    providerSettings,
-    serverEnv: env,
-  });
-  MODEL_LIST = list || MODEL_LIST;
-
-  return list;
-}
-
-// initializeModelList({})
-export { initializeModelList, providerBaseUrlEnvKeys, MODEL_LIST };
 
 // starter Templates
 


### PR DESCRIPTION
## Motivation

Up to now, some providers couldn't be configured via  the environment properly. The list of models remained empty

## What this PR contains

Previously, the list of models was retrieved from the front-end. If the list wasn't hard coded (like for many providers), the system tried to retrieve the models via the `/models` route of the provider. 
As the environment configuration which includes the API keys is intentionally not shared with the client, this request couldn't complete and failed silently on the client. 
This affected `openai like` and `openrouter` once they required api keys.

This PR implements a more robust and flexible approach to retrieving model lists by moving the initialization logic to the backend, enabling dynamic model discovery and configuration across different providers.

## Key Changes
1. Model List Retrieval
   Replaced static MODEL_LIST with dynamic backend-driven model fetching
   Created a new /api/models endpoint to serve model information
   Implemented useModels hook for frontend model access
2. Provider and Model Management
   Refactored model initialization to use LLMManager
   Added more flexible provider and model configuration
   Improved handling of API keys and provider settings
   Technical Details
   LLMManager

## Key implementation details:

- Enhanced updateModelList method to handle dynamic model discovery
- Improved provider configuration detection
- Added method to retrieve providers and default provider

## API Endpoints

`/api/models` now returns:
- Complete model list
- Available providers
- Default provider configuration

## Related

#1035