### PR TITLE
feat: add Github provider for language models

### DIFF
--- a/app/lib/modules/llm/providers/github.ts
+++ b/app/lib/modules/llm/providers/github.ts
@@ -1,0 +1,52 @@
+import { BaseProvider } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+
+export default class GithubProvider extends BaseProvider {
+  name = 'Github';
+  getApiKeyLink = 'https://github.com/settings/personal-access-tokens';
+
+  config = {
+    apiTokenKey: 'GITHUB_API_KEY',
+  };
+// find more in https://github.com/marketplace?type=models
+  staticModels: ModelInfo[] = [
+    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000 },
+    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-4-turbo', label: 'GPT-4 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
+  ];
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    const { apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: '',
+      defaultApiTokenKey: 'GITHUB_API_KEY',
+    });
+
+    if (!apiKey) {
+      throw new Error(`Missing API key for ${this.name} provider`);
+    }
+
+    const openai = createOpenAI({
+      baseURL: 'https://models.inference.ai.azure.com',
+      apiKey,
+    });
+
+    return openai(model);
+  }
+}

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -15,6 +15,7 @@ import TogetherProvider from './providers/together';
 import XAIProvider from './providers/xai';
 import HyperbolicProvider from './providers/hyperbolic';
 import AmazonBedrockProvider from './providers/amazon-bedrock';
+import GithubProvider from './providers/github';
 
 export {
   AnthropicProvider,
@@ -34,4 +35,5 @@ export {
   TogetherProvider,
   LMStudioProvider,
   AmazonBedrockProvider,
+  GithubProvider,
 };


### PR DESCRIPTION
### **1. Added New File: `github.ts`**  
**Location:** `app/lib/modules/llm/providers/github.ts`  
**Content:**  
- Created the `GithubProvider` class, which extends `BaseProvider`.  
- Defined available AI models from Github:  
  - `gpt-4o`, `o1`, `o1-mini`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`.  
- Integrated the API using the `GITHUB_API_KEY`.  
- Utilized the `@ai-sdk/openai` library to connect to the URL:  
  ```
  https://models.inference.ai.azure.com
  ```

---

### **2. Added `GithubProvider` to the Provider Management System**  
**File:** `app/lib/modules/llm/registry.ts`  
**Content:**  
- Imported `GithubProvider` into the system.  
- Registered the new provider in the export list.

---

### **Significance of This PR**  
**Objective:**  
- Expand the system to support additional language models from **Github**.  

**Benefits:**  
- Increases flexibility in selecting AI models.  
- Simplifies integration with additional AI services from the **Github Marketplace**.