### PR TITLE
fix: get environment variables for docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
     image: bolt-ai:development
     build:
       target: bolt-ai-development
+    env_file: ".env.local"
     environment:
       - NODE_ENV=development
       - VITE_HMR_PROTOCOL=ws


### PR DESCRIPTION
Environment variables are not being passed to the container in the development profile. Adding env_file to pass them so they can be used by the application. Confirmed that this fixes the issue locally with the latest code on main.