### PR TITLE
fix(docker): add build context to app-dev service in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
   app-dev:
     image: bolt-ai:development
     build:
+      context: .
+      dockerfile: Dockerfile
       target: bolt-ai-development
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
Fix invalid docker-compose configuration by adding missing build context properties to app-dev service.

This PR resolves the following error:
`ERROR: The Compose file is invalid because: Service app-dev has neither an image nor a build context specified. At least one must be provided.`

Changes:
- Added build.context and build.dockerfile properties to app-dev service
- Aligned build configuration with existing app-prod service structure