### PR TITLE
refactor: implement direct preview url opening in new tab

### DIFF
--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -7,19 +7,23 @@ import { ScreenshotSelector } from './ScreenshotSelector';
 
 type ResizeSide = 'left' | 'right' | null;
 
-interface WindowSize {
-  name: string;
-  width: number;
-  height: number;
-  icon: string;
-}
+/*
+ * interface WindowSize {
+ * name: string;
+ * width: number;
+ * height: number;
+ * icon: string;
+ * }
+ */
 
-const WINDOW_SIZES: WindowSize[] = [
-  { name: 'Mobile', width: 375, height: 667, icon: 'i-ph:device-mobile' },
-  { name: 'Tablet', width: 768, height: 1024, icon: 'i-ph:device-tablet' },
-  { name: 'Laptop', width: 1366, height: 768, icon: 'i-ph:laptop' },
-  { name: 'Desktop', width: 1920, height: 1080, icon: 'i-ph:monitor' },
-];
+/*
+ * const WINDOW_SIZES: WindowSize[] = [
+ * { name: 'Mobile', width: 375, height: 667, icon: 'i-ph:device-mobile' },
+ * { name: 'Tablet', width: 768, height: 1024, icon: 'i-ph:device-tablet' },
+ * { name: 'Laptop', width: 1366, height: 768, icon: 'i-ph:laptop' },
+ * { name: 'Desktop', width: 1920, height: 1080, icon: 'i-ph:monitor' },
+ *];
+ */
 
 export const Preview = memo(() => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -54,8 +58,10 @@ export const Preview = memo(() => {
 
   const SCALING_FACTOR = 2;
 
-  const [isWindowSizeDropdownOpen, setIsWindowSizeDropdownOpen] = useState(false);
-  const [selectedWindowSize, setSelectedWindowSize] = useState<WindowSize>(WINDOW_SIZES[0]);
+  /*
+   * const [isWindowSizeDropdownOpen, setIsWindowSizeDropdownOpen] = useState(false);
+   * const [selectedWindowSize, setSelectedWindowSize] = useState<WindowSize>(WINDOW_SIZES[0]);
+   */
 
   useEffect(() => {
     if (!activePreview) {
@@ -220,27 +226,47 @@ export const Preview = memo(() => {
     </div>
   );
 
-  const openInNewWindow = (size: WindowSize) => {
-    if (activePreview?.baseUrl) {
-      const match = activePreview.baseUrl.match(/^https?:\/\/([^.]+)\.local-credentialless\.webcontainer-api\.io/);
+  /// NEW OFFICIAL METHOD OF OPEN IN NEW TAB AS SEEN IN BOLT.NEW///
+  const openInNewWindow = () => {
+    if (activePreview && activePreview.baseUrl) {
+      const url = activePreview.baseUrl;
 
-      if (match) {
-        const previewId = match[1];
-        const previewUrl = `/webcontainer/preview/${previewId}`;
-        const newWindow = window.open(
-          previewUrl,
-          '_blank',
-          `noopener,noreferrer,width=${size.width},height=${size.height},menubar=no,toolbar=no,location=no,status=no`,
-        );
+      const newWindow = window.open(url, '_blank');
 
-        if (newWindow) {
-          newWindow.focus();
-        }
-      } else {
-        console.warn('[Preview] Invalid WebContainer URL:', activePreview.baseUrl);
+      if (newWindow) {
+        newWindow.focus();
       }
+    } else {
+      console.warn('[Preview] Invalid WebContainer URL:', activePreview?.baseUrl);
     }
   };
+
+  /// OLD VERSION OF OPEN IN NEW TAB ///
+  {
+    /*
+     *const openInNewWindow = (size: WindowSize) => {
+     *if (activePreview?.baseUrl) {
+     *const match = activePreview.baseUrl.match(/^https?:\/\/([^.]+)\.local-credentialless\.webcontainer-api\.io/);
+     *
+     *if (match) {
+     *  const previewId = match[1];
+     *  const previewUrl = `/webcontainer/preview/${previewId}`;
+     *  const newWindow = window.open(
+     *    previewUrl,
+     *    '_blank',
+     *    `noopener,noreferrer,width=${size.width},height=${size.height},menubar=no,toolbar=no,location=no,status=no`,
+     *  );
+     *
+     *  if (newWindow) {
+     *    newWindow.focus();
+     *  }
+     *} else {
+     *  console.warn('[Preview] Invalid WebContainer URL:', activePreview.baseUrl);
+     *}
+     *}
+     *};
+     */
+  }
 
   return (
     <div
@@ -315,9 +341,10 @@ export const Preview = memo(() => {
           <div className="flex items-center relative">
             <IconButton
               icon="i-ph:arrow-square-out"
-              onClick={() => openInNewWindow(selectedWindowSize)}
-              title={`Open Preview in ${selectedWindowSize.name} Window`}
+              onClick={() => openInNewWindow()}
+              title={`Open Preview in new tab`}
             />
+            {/* Not Needed now that we can open in new tab using official methods
             <IconButton
               icon="i-ph:caret-down"
               onClick={() => setIsWindowSizeDropdownOpen(!isWindowSizeDropdownOpen)}
@@ -354,7 +381,7 @@ export const Preview = memo(() => {
                   ))}
                 </div>
               </>
-            )}
+            )}*/}
           </div>
         </div>
       </div>

--- a/app/lib/modules/llm/providers/groq.ts
+++ b/app/lib/modules/llm/providers/groq.ts
@@ -19,7 +19,12 @@ export default class GroqProvider extends BaseProvider {
     { name: 'llama-3.2-3b-preview', label: 'Llama 3.2 3b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
     { name: 'llama-3.2-1b-preview', label: 'Llama 3.2 1b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
     { name: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
-    { name: 'deepseek-r1-distill-llama-70b', label: 'Deepseek R1 Distill Llama 70b (Groq)', provider: 'Groq', maxTokenAllowed: 131072 },
+    {
+      name: 'deepseek-r1-distill-llama-70b',
+      label: 'Deepseek R1 Distill Llama 70b (Groq)',
+      provider: 'Groq',
+      maxTokenAllowed: 131072,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/routes/webcontainer.connect.$id.tsx
+++ b/app/routes/webcontainer.connect.$id.tsx
@@ -1,0 +1,34 @@
+// app/routes/webcontainer/connect.ts
+
+import { type LoaderFunction } from '@remix-run/cloudflare';
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const url = new URL(request.url);
+  const editorOrigin = url.searchParams.get('editorOrigin') || 'https://stackblitz.com';
+  console.log('editorOrigin', editorOrigin);
+
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Connect to WebContainer</title>
+      </head>
+      <body>
+        <script type="module">
+          (async () => {
+            const { setupConnect } = await import('https://cdn.jsdelivr.net/npm/@webcontainer/api@latest/dist/connect.js');
+            setupConnect({
+              editorOrigin: '${editorOrigin}'
+            });
+          })();
+        </script>
+      </body>
+    </html>
+  `;
+
+  return new Response(htmlContent, {
+    headers: { 'Content-Type': 'text/html' },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@remix-run/react": "^2.15.0",
     "@uiw/codemirror-theme-vscode": "^4.23.6",
     "@unocss/reset": "^0.61.9",
-    "@webcontainer/api": "1.3.0-internal.10",
+    "@webcontainer/api": "1.5.1-internal.6",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^0.61.9
         version: 0.61.9
       '@webcontainer/api':
-        specifier: 1.3.0-internal.10
-        version: 1.3.0-internal.10
+        specifier: 1.5.1-internal.6
+        version: 1.5.1-internal.6
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -2824,8 +2824,8 @@ packages:
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
-  '@webcontainer/api@1.3.0-internal.10':
-    resolution: {integrity: sha512-iuqjuDX2uADiJMYZok7+tJqVCJYZ+tU2NwVtxlvakRWSSmIFBGrJ38pD0C5igaOnBV8C9kGDjCE6B03SvLtN4Q==}
+  '@webcontainer/api@1.5.1-internal.6':
+    resolution: {integrity: sha512-HErRz351Wa2porp9AZAeKqzwyl9UIuj09hQyKLLzDdT+p/VOKyCeWghV0wBhuzJA1K4gExvyCzblnOPaJq0trg==}
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -9288,7 +9288,7 @@ snapshots:
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
-  '@webcontainer/api@1.3.0-internal.10': {}
+  '@webcontainer/api@1.5.1-internal.6': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:


### PR DESCRIPTION
This PR simplifies the preview window functionality by implementing a direct URL opening mechanism in new tabs. Key changes include:

- Removed the complex window size selection dropdown and related functionality
- Simplified the "Open in New Tab" feature to use the built in WebContainer behaviour
- Streamlined the preview opening process by utilizing the direct URL approach
- Removed unused WindowSize interface and WINDOW_SIZES constant
- Maintained all existing preview functionality while reducing code complexity
- Fix linting error in groq.ts 

This change improves the user experience by providing a more straightforward way to open previews in new tabs while reducing the maintenance overhead of the codebase.