### PR TITLE
feat: support for <think></think> tags to allow reasoning tokens formatted in UI

### DIFF
--- a/app/lib/modules/llm/providers/groq.ts
+++ b/app/lib/modules/llm/providers/groq.ts
@@ -19,7 +19,12 @@ export default class GroqProvider extends BaseProvider {
     { name: 'llama-3.2-3b-preview', label: 'Llama 3.2 3b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
     { name: 'llama-3.2-1b-preview', label: 'Llama 3.2 1b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
     { name: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70b (Groq)', provider: 'Groq', maxTokenAllowed: 8000 },
-    { name: 'deepseek-r1-distill-llama-70b', label: 'Deepseek R1 Distill Llama 70b (Groq)', provider: 'Groq', maxTokenAllowed: 131072 },
+    {
+      name: 'deepseek-r1-distill-llama-70b',
+      label: 'Deepseek R1 Distill Llama 70b (Groq)',
+      provider: 'Groq',
+      maxTokenAllowed: 131072,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/utils/markdown.ts
+++ b/app/utils/markdown.ts
@@ -54,7 +54,27 @@ export const allowedHTMLElements = [
   'tr',
   'ul',
   'var',
+  'think',
 ];
+
+// Add custom rehype plugin
+function remarkThinkRawContent() {
+  return (tree: any) => {
+    visit(tree, (node: any) => {
+      if (node.type === 'html' && node.value && node.value.startsWith('<think>')) {
+        const cleanedContent = node.value.slice(7);
+        node.value = `<div class="__boltThought__">${cleanedContent}`;
+
+        return;
+      }
+
+      if (node.type === 'html' && node.value && node.value.startsWith('</think>')) {
+        const cleanedContent = node.value.slice(8);
+        node.value = `</div>${cleanedContent}`;
+      }
+    });
+  };
+}
 
 const rehypeSanitizeOptions: RehypeSanitizeOptions = {
   ...defaultSchema,
@@ -78,6 +98,8 @@ export function remarkPlugins(limitedMarkdown: boolean) {
   if (limitedMarkdown) {
     plugins.unshift(limitedMarkdownPlugin);
   }
+
+  plugins.unshift(remarkThinkRawContent);
 
   return plugins;
 }


### PR DESCRIPTION
some of the providers of deepseek is using `<think>` tag to stream thinking token directly in the response.
this PR detects that and enclose that inside a container for better user experience 

example provider `Groq`, `ollama` with deepseek models