### PR TITLE
Coolify deploy configuration WORKING AND DONE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,92 +1,29 @@
-ARG BASE=node:20.18.0
-FROM ${BASE} AS base
+FROM node:20.18.0 AS base
 
 WORKDIR /app
 
-# Install dependencies (this step is cached as long as the dependencies don't change)
+# Instalar pnpm
+RUN corepack enable pnpm
+
+# Copiar arquivos de dependências
 COPY package.json pnpm-lock.yaml ./
 
-RUN corepack enable pnpm && pnpm install
+# Instalar dependências
+RUN pnpm install
 
-# Copy the rest of your app's source code
+# Copiar código fonte
 COPY . .
 
-# Expose the port the app runs on
-EXPOSE 5173
-
-# Production image
-FROM base AS bolt-ai-production
-
-# Define environment variables with default values or let them be overridden
-ARG GROQ_API_KEY
-ARG HuggingFace_API_KEY
-ARG OPENAI_API_KEY
-ARG ANTHROPIC_API_KEY
-ARG OPEN_ROUTER_API_KEY
-ARG GOOGLE_GENERATIVE_AI_API_KEY
-ARG OLLAMA_API_BASE_URL
-ARG XAI_API_KEY
-ARG TOGETHER_API_KEY
-ARG TOGETHER_API_BASE_URL
-ARG AWS_BEDROCK_CONFIG
-ARG VITE_LOG_LEVEL=debug
-ARG DEFAULT_NUM_CTX
-
-ENV WRANGLER_SEND_METRICS=false \
-    GROQ_API_KEY=${GROQ_API_KEY} \
-    HuggingFace_KEY=${HuggingFace_API_KEY} \
-    OPENAI_API_KEY=${OPENAI_API_KEY} \
-    ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
-    OPEN_ROUTER_API_KEY=${OPEN_ROUTER_API_KEY} \
-    GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
-    OLLAMA_API_BASE_URL=${OLLAMA_API_BASE_URL} \
-    XAI_API_KEY=${XAI_API_KEY} \
-    TOGETHER_API_KEY=${TOGETHER_API_KEY} \
-    TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL} \
-    AWS_BEDROCK_CONFIG=${AWS_BEDROCK_CONFIG} \
-    VITE_LOG_LEVEL=${VITE_LOG_LEVEL} \
-    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}\
-    RUNNING_IN_DOCKER=true
-
-# Pre-configure wrangler to disable metrics
-RUN mkdir -p /root/.config/.wrangler && \
-    echo '{"enabled":false}' > /root/.config/.wrangler/metrics.json
-
+# Build da aplicação
 RUN pnpm run build
 
-CMD [ "pnpm", "run", "dockerstart"]
+# Expor porta
+EXPOSE 5173
 
-# Development image
-FROM base AS bolt-ai-development
+# Configurar variáveis de ambiente padrão
+ENV NODE_ENV=production \
+    RUNNING_IN_DOCKER=true \
+    WRANGLER_SEND_METRICS=false
 
-# Define the same environment variables for development
-ARG GROQ_API_KEY
-ARG HuggingFace 
-ARG OPENAI_API_KEY
-ARG ANTHROPIC_API_KEY
-ARG OPEN_ROUTER_API_KEY
-ARG GOOGLE_GENERATIVE_AI_API_KEY
-ARG OLLAMA_API_BASE_URL
-ARG XAI_API_KEY
-ARG TOGETHER_API_KEY
-ARG TOGETHER_API_BASE_URL
-ARG VITE_LOG_LEVEL=debug
-ARG DEFAULT_NUM_CTX
-
-ENV GROQ_API_KEY=${GROQ_API_KEY} \
-    HuggingFace_API_KEY=${HuggingFace_API_KEY} \
-    OPENAI_API_KEY=${OPENAI_API_KEY} \
-    ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
-    OPEN_ROUTER_API_KEY=${OPEN_ROUTER_API_KEY} \
-    GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
-    OLLAMA_API_BASE_URL=${OLLAMA_API_BASE_URL} \
-    XAI_API_KEY=${XAI_API_KEY} \
-    TOGETHER_API_KEY=${TOGETHER_API_KEY} \
-    TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL} \
-    AWS_BEDROCK_CONFIG=${AWS_BEDROCK_CONFIG} \
-    VITE_LOG_LEVEL=${VITE_LOG_LEVEL} \
-    DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX}\
-    RUNNING_IN_DOCKER=true
-
-RUN mkdir -p ${WORKDIR}/run
-CMD pnpm run dev --host
+# Comando para iniciar
+CMD ["pnpm", "run", "dockerstart"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,12 @@
 services:
-  app-prod:
-    image: bolt-ai:production
+  app:
     build:
       context: .
       dockerfile: Dockerfile
-      target: bolt-ai-production
     ports:
       - "5173:5173"
-    env_file: ".env.local"
     environment:
       - NODE_ENV=production
-      - COMPOSE_PROFILES=production
-      # No strictly needed but serving as hints for Coolify
       - PORT=5173
       - GROQ_API_KEY=${GROQ_API_KEY}
       - HuggingFace_API_KEY=${HuggingFace_API_KEY}
@@ -26,12 +21,7 @@ services:
       - AWS_BEDROCK_CONFIG=${AWS_BEDROCK_CONFIG}
       - VITE_LOG_LEVEL=${VITE_LOG_LEVEL:-debug}
       - DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX:-32768}
-      - RUNNING_IN_DOCKER=true
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    command: pnpm run dockerstart
-    profiles:
-      - production
+    restart: unless-stopped
 
   app-dev:
     image: bolt-ai:development


### PR DESCRIPTION
refactor: simplifica configuração do Docker Compose para deploy no Coolify

- Remove estágios múltiplos de build para evitar conflitos no deploy
- Simplifica para um único perfil de produção
- Ajusta configuração da porta para 5173
- Remove comandos de build e start redundantes
- Otimiza a estrutura do docker-compose para melhor compatibilidade com Coolify


refactor: simplify Docker Compose configuration for Coolify deployment

- Remove multiple build stages to prevent deployment conflicts
- Simplify to a single production profile
- Adjust port configuration to 5173
- Remove redundant build and start commands
- Optimize docker-compose structure for better Coolify compatibility

![image](https://github.com/user-attachments/assets/8f705818-d874-47a4-85f4-855098c7669f)
