### PR TITLE
fix: prompt typo shoudl in select-context.ts

### DIFF
--- a/app/lib/.server/llm/select-context.ts
+++ b/app/lib/.server/llm/select-context.ts
@@ -138,7 +138,7 @@ export async function selectContext(props: {
         Now, you are given a task. You need to select the files that are relevant to the task from the list of files above.
 
         RESPONSE FORMAT:
-        your response shoudl be in following format:
+        your response should be in following format:
 ---
 <updateContextBuffer>
     <includeFile path="path/to/file"/>


### PR DESCRIPTION
I was browsing this code when I noticed a typo "shoudl" in the prompt