### PR TITLE
feat: adding Gemini 2.0 Pro Experimental 02-05 model

### DIFF
--- a/app/lib/modules/llm/providers/google.ts
+++ b/app/lib/modules/llm/providers/google.ts
@@ -13,14 +13,10 @@ export default class GoogleProvider extends BaseProvider {
   };
 
   staticModels: ModelInfo[] = [
-    { name: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash', provider: 'Google', maxTokenAllowed: 8192 },
-    {
-      name: 'gemini-2.0-flash-thinking-exp-01-21',
-      label: 'Gemini 2.0 Flash-thinking-exp-01-21',
-      provider: 'Google',
-      maxTokenAllowed: 65536,
-    },
     { name: 'gemini-2.0-flash-exp', label: 'Gemini 2.0 Flash', provider: 'Google', maxTokenAllowed: 8192 },
+    { name: 'gemini-2.0-pro-exp-02-05', label: 'Gemini 2.0 Pro Experimental 02-05', provider: 'Google', maxTokenAllowed: 8192 },
+    { name: 'gemini-2.0-flash-thinking-exp-01-21', label: 'Gemini 2.0 Flash-thinking-exp-01-21', provider: 'Google', maxTokenAllowed: 8192 },
+    { name: 'gemini-1.5-flash-latest', label: 'Gemini 1.5 Flash', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-flash-002', label: 'Gemini 1.5 Flash-002', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash-8b', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-pro-latest', label: 'Gemini 1.5 Pro', provider: 'Google', maxTokenAllowed: 8192 },


### PR DESCRIPTION
Adding Gemini 2.0 Pro Experimental 02-05 which is currently in preview mode free of charge

<img width="777" alt="Screenshot 2025-02-08 at 22 32 56" src="https://github.com/user-attachments/assets/41414d73-01cb-4a56-84d0-0dd19f1495d8" />
