### PR TITLE
fix: broken astro project git clone

### DIFF
--- a/app/components/chat/GitCloneButton.tsx
+++ b/app/components/chat/GitCloneButton.tsx
@@ -70,7 +70,7 @@ export default function GitCloneButton({ importChat, className }: GitCloneButton
           // Skip binary files
           if (
             content instanceof Uint8Array &&
-            !filePath.match(/\.(txt|md|js|jsx|ts|tsx|json|html|css|scss|less|yml|yaml|xml|svg)$/i)
+            !filePath.match(/\.(txt|md|astro|mjs|js|jsx|ts|tsx|json|html|css|scss|less|yml|yaml|xml|svg)$/i)
           ) {
             skippedFiles.push(filePath);
             continue;


### PR DESCRIPTION
When git cloning an astro project, all `.astro` files as well as the astro config file `astro.config.mjs` are skipped and becomes a broken project that is no longer previewable.