### PR TITLE
feat: make user made changes persistent after reload

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -321,17 +321,17 @@ export const ChatImpl = memo(
               const { assistantMessage, userMessage } = temResp;
               setMessages([
                 {
-                  id: `${new Date().getTime()}`,
+                  id: `1-${new Date().getTime()}`,
                   role: 'user',
                   content: messageContent,
                 },
                 {
-                  id: `${new Date().getTime()}`,
+                  id: `2-${new Date().getTime()}`,
                   role: 'assistant',
                   content: assistantMessage,
                 },
                 {
-                  id: `${new Date().getTime()}`,
+                  id: `3-${new Date().getTime()}`,
                   role: 'user',
                   content: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${userMessage}`,
                   annotations: ['hidden'],

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -25,6 +25,7 @@ import { createSampler } from '~/utils/sampler';
 import { getTemplates, selectStarterTemplate } from '~/utils/selectStarterTemplate';
 import { logStore } from '~/lib/stores/logs';
 import { streamingState } from '~/lib/stores/streaming';
+import { filesToArtifacts } from '~/utils/fileUtils';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -371,17 +372,18 @@ export const ChatImpl = memo(
         setMessages(messages.slice(0, -1));
       }
 
-      const fileModifications = workbenchStore.getFileModifcations();
+      const modifiedFiles = workbenchStore.getModifiedFiles();
 
       chatStore.setKey('aborted', false);
 
-      if (fileModifications !== undefined) {
+      if (modifiedFiles !== undefined) {
+        const userUpdateArtifact = filesToArtifacts(modifiedFiles, `${Date.now()}`);
         append({
           role: 'user',
           content: [
             {
               type: 'text',
-              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${messageContent}`,
+              text: `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${userUpdateArtifact}${messageContent}`,
             },
             ...imageDataList.map((imageData) => ({
               type: 'image',

--- a/app/components/chat/UserMessage.tsx
+++ b/app/components/chat/UserMessage.tsx
@@ -43,5 +43,6 @@ export function UserMessage({ content }: UserMessageProps) {
 }
 
 function stripMetadata(content: string) {
-  return content.replace(MODEL_REGEX, '').replace(PROVIDER_REGEX, '');
+  const artifactRegex = /<boltArtifact\s+[^>]*>[\s\S]*?<\/boltArtifact>/gm;
+  return content.replace(MODEL_REGEX, '').replace(PROVIDER_REGEX, '').replace(artifactRegex, '');
 }

--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -42,6 +42,10 @@ const messageParser = new StreamingMessageParser({
     },
   },
 });
+const extractTextContent = (message: Message) =>
+  Array.isArray(message.content)
+    ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
+    : message.content;
 
 export function useMessageParser() {
   const [parsedMessages, setParsedMessages] = useState<{ [key: number]: string }>({});
@@ -55,9 +59,8 @@ export function useMessageParser() {
     }
 
     for (const [index, message] of messages.entries()) {
-      if (message.role === 'assistant') {
-        const newParsedContent = messageParser.parse(message.id, message.content);
-
+      if (message.role === 'assistant' || message.role === 'user') {
+        const newParsedContent = messageParser.parse(message.id, extractTextContent(message));
         setParsedMessages((prevParsed) => ({
           ...prevParsed,
           [index]: !reset ? (prevParsed[index] || '') + newParsedContent : newParsedContent,

--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -75,6 +75,29 @@ export class FilesStore {
   getFileModifications() {
     return computeFileModifications(this.files.get(), this.#modifiedFiles);
   }
+  getModifiedFiles() {
+    let modifiedFiles: { [path: string]: File } | undefined = undefined;
+
+    for (const [filePath, originalContent] of this.#modifiedFiles) {
+      const file = this.files.get()[filePath];
+
+      if (file?.type !== 'file') {
+        continue;
+      }
+
+      if (file.content === originalContent) {
+        continue;
+      }
+
+      if (!modifiedFiles) {
+        modifiedFiles = {};
+      }
+
+      modifiedFiles[filePath] = file;
+    }
+
+    return modifiedFiles;
+  }
 
   resetFileModifications() {
     this.#modifiedFiles.clear();

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -238,6 +238,9 @@ export class WorkbenchStore {
   getFileModifcations() {
     return this.#filesStore.getFileModifications();
   }
+  getModifiedFiles() {
+    return this.#filesStore.getModifiedFiles();
+  }
 
   resetAllFileModifications() {
     this.#filesStore.resetFileModifications();

--- a/app/utils/fileUtils.ts
+++ b/app/utils/fileUtils.ts
@@ -103,3 +103,19 @@ export const detectProjectType = async (
 
   return { type: '', setupCommand: '', followupMessage: '' };
 };
+
+export const filesToArtifacts = (files: { [path: string]: { content: string } }, id: string): string => {
+  return `
+<boltArtifact id="${id}" title="User Updated Files">
+${Object.keys(files)
+  .map(
+    (filePath) => `
+<boltAction type="file" filePath="${filePath}">
+${files[filePath].content}
+</boltAction>
+`,
+  )
+  .join('\n')}
+</boltArtifact>
+  `;
+};


### PR DESCRIPTION
# Persist User File Changes via Artifacts

## Overview
This PR implements a mechanism to persist user file modifications across reload by automatically capturing all file changes and embedding them as artifacts in the next user message. These artifacts are invisible to users but contain all necessary file change data. Critically, the message parser has been extended to process both assistant AND user messages (previously only processed assistant messages), ensuring these file change artifacts are executed upon reload, reconstructing the user's file modifications.

## Key Changes
### 1. File Modification Persistence
- **Automatic capture**: System now captures any file changes made by the user
- **Artifact generation**: Added `filesToArtifacts` utility to convert these modified files into a structured artifact format
- **Artifact attachment**: Automatically prepends these file artifacts to the next user message the user sends
- **Key workflow**: User makes file changes → system captures changes → changes are attached to next user message → changes persist across reloads

### 2. Message Parser Enhancement
- **Critical change**: Extended message parser to process USER messages (previously only parsed assistant messages)
- **Parser execution**: Message parser now executes the file change artifacts found in user messages
- **Reconstruction**: Upon reload, when messages are loaded, parser executes artifacts to reconstruct file changes
- Added new `getModifiedFiles` method to efficiently retrieve only modified files for artifact creation

## Technical Details
### File Artifact Generation
Key technical implementation details:
- Created a timestamp-based unique ID for each artifact
- Structured file artifacts with clear file paths and content
- Implemented as invisible markup that doesn't interfere with the user experience

### Message Parser Enhancement
- Extended parser to handle user messages, which it previously didn't process at all
- Added helper function `extractTextContent` to normalize message content extraction
- Modified condition from `message.role === 'assistant'` to `message.role === 'assistant' || message.role === 'user'`
- Ensured backward compatibility with existing message formats while enabling artifact execution

## Testing
- Verified persistence of file changes across page reloads
- Tested with multiple files being modified simultaneously
- Validated correct reconstruction of file states after reload
- Confirmed artifacts don't affect message display

## Migration Impact
- No breaking changes or migration steps required
- Fully backward compatible with existing messages
- Seamless integration with current workflow

## Future Improvements
- Consider optimizing artifact size for large file changes
- Add support for file deletions and creations

## Preview

https://github.com/user-attachments/assets/6c2570b8-87ac-4670-a0e6-638afaf1daf8



