### PR TITLE
feat(llm): add Claude 3.7 Sonnet model and update API key reference

### DIFF
--- a/app/lib/modules/llm/providers/anthropic.ts
+++ b/app/lib/modules/llm/providers/anthropic.ts
@@ -14,6 +14,12 @@ export default class AnthropicProvider extends BaseProvider {
 
   staticModels: ModelInfo[] = [
     {
+      name: 'claude-3-7-sonnet-20250219',
+      label: 'Claude 3.7 Sonnet',
+      provider: 'Anthropic',
+      maxTokenAllowed: 8000,
+    },
+    {
       name: 'claude-3-5-sonnet-latest',
       label: 'Claude 3.5 Sonnet (new)',
       provider: 'Anthropic',
@@ -46,7 +52,7 @@ export default class AnthropicProvider extends BaseProvider {
       providerSettings: settings,
       serverEnv: serverEnv as any,
       defaultBaseUrlKey: '',
-      defaultApiTokenKey: 'OPENAI_API_KEY',
+      defaultApiTokenKey: 'ANTHROPIC_API_KEY',
     });
 
     if (!apiKey) {


### PR DESCRIPTION

## Changes

- Added support for the new Claude 3.7 Sonnet model to the Anthropic provider
- Updated model listings to include the latest Claude offerings
- Maintained consistent token limit specification for all Claude models

## Details

This PR adds support for Anthropic's newest Claude 3.7 Sonnet model (`claude-3-7-sonnet-20250219`), which provides enhanced capabilities over previous Claude versions. The model is now available in the static models list with appropriate configurations.

The update maintains the existing pattern for model configuration with 8000 tokens as the maximum allowed, consistent with other Claude models in the application. This ensures that users can seamlessly work with the new model following the same patterns as with other Claude models.

## Testing

- Verified that the new model appears correctly in the model selection UI
- Confirmed that the model can be used for inference when a valid API key is provided
- Ensured compatibility with existing application functionality

## Related

- [Anthropic Claude 3.7 Release Notes](https://www.anthropic.com/news/claude-3-7-sonnet)
