### PR TITLE
Add custom prompt to library

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -28,6 +28,7 @@ export async function streamText(props: {
   contextFiles?: FileMap;
   summary?: string;
   messageSliceId?: number;
+  customPrompt?: string;
 }) {
   const {
     messages,
@@ -40,6 +41,7 @@ export async function streamText(props: {
     contextOptimization,
     contextFiles,
     summary,
+    customPrompt,
   } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
@@ -92,12 +94,29 @@ export async function streamText(props: {
 
   const dynamicMaxTokens = modelDetails && modelDetails.maxTokenAllowed ? modelDetails.maxTokenAllowed : MAX_TOKENS;
 
-  let systemPrompt =
-    PromptLibrary.getPropmtFromLibrary(promptId || 'default', {
-      cwd: WORK_DIR,
-      allowedHtmlElements: allowedHTMLElements,
-      modificationTagName: MODIFICATIONS_TAG_NAME,
-    }) ?? getSystemPrompt();
+  let systemPrompt;
+
+  if (promptId === 'custom') {
+    if (customPrompt && customPrompt.trim()) {
+      systemPrompt = customPrompt;
+    } else {
+      systemPrompt =
+        PromptLibrary.getPropmtFromLibrary('default', {
+          cwd: WORK_DIR,
+          allowedHtmlElements: allowedHTMLElements,
+          modificationTagName: MODIFICATIONS_TAG_NAME,
+        }) ?? getSystemPrompt();
+
+      logger.warn('Custom prompt selected but no custom prompt provided, falling back to default prompt');
+    }
+  } else {
+    systemPrompt =
+      PromptLibrary.getPropmtFromLibrary(promptId || 'default', {
+        cwd: WORK_DIR,
+        allowedHtmlElements: allowedHTMLElements,
+        modificationTagName: MODIFICATIONS_TAG_NAME,
+      }) ?? getSystemPrompt();
+  }
 
   if (files && contextFiles && contextOptimization) {
     const codeContext = createFilesContext(contextFiles, true);

--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -7,6 +7,9 @@ export interface PromptOptions {
   modificationTagName: string;
 }
 
+// Define a constant for the localStorage key
+export const CUSTOM_PROMPT_STORAGE_KEY = 'custom_prompt';
+
 export class PromptLibrary {
   static library: Record<
     string,
@@ -26,6 +29,21 @@ export class PromptLibrary {
       description: 'an Experimental version of the prompt for lower token usage',
       get: (options) => optimized(options),
     },
+    custom: {
+      label: 'Custom Prompt',
+      description: 'Your own custom system prompt',
+      get: (_options) => {
+        // Get the custom prompt from localStorage if available
+        if (typeof window !== 'undefined') {
+          const customPrompt = localStorage.getItem(CUSTOM_PROMPT_STORAGE_KEY);
+          return customPrompt && customPrompt.trim()
+            ? customPrompt
+            : 'No custom prompt defined. Please set a custom prompt in the settings.';
+        }
+
+        return 'Custom prompt not available';
+      },
+    },
   };
   static getList() {
     return Object.entries(this.library).map(([key, value]) => {
@@ -41,9 +59,43 @@ export class PromptLibrary {
     const prompt = this.library[promptId];
 
     if (!prompt) {
-      throw 'Prompt Now Found';
+      throw 'Prompt Not Found';
     }
 
     return this.library[promptId]?.get(options);
+  }
+
+  // Helper method to save a custom prompt to localStorage
+  static saveCustomPrompt(promptText: string): void {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(CUSTOM_PROMPT_STORAGE_KEY, promptText);
+
+      // Dispatch a storage event to notify other tabs/windows
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: CUSTOM_PROMPT_STORAGE_KEY,
+          newValue: promptText,
+        }),
+      );
+    }
+  }
+
+  // Helper method to get the current custom prompt from localStorage
+  static getCustomPrompt(): string {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(CUSTOM_PROMPT_STORAGE_KEY) || '';
+    }
+
+    return '';
+  }
+
+  // Helper method to check if a custom prompt exists
+  static hasCustomPrompt(): boolean {
+    if (typeof window !== 'undefined') {
+      const prompt = localStorage.getItem(CUSTOM_PROMPT_STORAGE_KEY);
+      return !!prompt && prompt.trim().length > 0;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
# Why this feature

For those that want to customize an existing deployed instance of bolt.diy, there should be an easy way to tweak the system prompt and play with variations of it. For example: you should be able to add specific guidelines about the stack that can be reused over and over across multiple chats. I find myself using this constantly while building shopify apps and injecting extra context to the prompt about polaris ui and polaris icons.

# Approach

I'm persisting the custom prompt to localStorage as it can easily exceed the limits of a session token. I haven't touched the "default" and "optimized" prompts which are still available in the dropdown. There is an explicit save action and toast that confirms the custom prompt has been updated. The UI could use some work but I wanted to keep things basic for now.

Happy to integrate any feedback you have!