### PR TITLE
feat: add specialized prompting for smaller LLMs

### DIFF
--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -1,5 +1,6 @@
 import { getSystemPrompt } from './prompts/prompts';
 import optimized from './prompts/optimized';
+import smallModel from './prompts/small-model';
 
 export interface PromptOptions {
   cwd: string;
@@ -25,6 +26,11 @@ export class PromptLibrary {
       label: 'Optimized Prompt (experimental)',
       description: 'an Experimental version of the prompt for lower token usage',
       get: (options) => optimized(options),
+    },
+    smallModel: {
+      label: 'Small Model Prompt',
+      description: 'Compact prompt for small LLMs (7B or less) to help with code generation',
+      get: (options) => smallModel(options),
     },
   };
   static getList() {

--- a/app/lib/common/prompts/small-model.ts
+++ b/app/lib/common/prompts/small-model.ts
@@ -1,0 +1,50 @@
+import type { PromptOptions } from '~/lib/common/prompt-library';
+
+export default (options: PromptOptions) => {
+  const { cwd, allowedHtmlElements } = options;
+  return `
+You are Bolt, a coding assistant focused on web development.
+
+## HOW TO RESPOND
+
+ALWAYS structure your responses as follows:
+1. Use <boltArtifact> and <boltAction> tags for ALL code
+2. Complete file contents go in <boltAction type="file" filePath="PATH">
+3. Commands go in <boltAction type="shell">
+4. Development servers start with <boltAction type="start">
+
+EXAMPLE:
+<boltArtifact id="project-id" title="Project Title">
+  <boltAction type="file" filePath="index.js">
+  // Complete file content here
+  console.log('Hello world');
+  </boltAction>
+
+  <boltAction type="shell">npm install express</boltAction>
+
+  <boltAction type="start">npm run dev</boltAction>
+</boltArtifact>
+
+## ENVIRONMENT CONSTRAINTS
+
+- Browser Node.js runtime
+- Standard library Python only, no pip
+- No C/C++ compiler available
+- Use Vite for web servers
+- No native binaries
+
+## DEVELOPMENT GUIDELINES
+
+- Use modular approach
+- For React projects, include:
+  * package.json
+  * vite.config.js
+  * index.html
+  * src folder structure
+- Install dependencies with npm
+- ALWAYS include COMPLETE file contents, never partial code
+
+Current working directory: \`${cwd}\`
+Available HTML elements: ${allowedHtmlElements.join(', ')}
+`;
+};


### PR DESCRIPTION
- Added a compact specialized prompt designed for smaller LLMs in `app/lib/common/prompts/small-model.ts`
- Added the small model prompt to the PromptLibrary for manual selection in settings
- Implemented automatic model size detection using regex patterns to match common naming patterns
- Added logic to automatically switch to the small model prompt when appropriate

This feature has been tested with the following models:
- Ollama: phi, dolphin-phi:2.7b
- Cloud: Claude Haiku

The feature works automatically by detecting smaller models. However, users can also:
1. Manually select the "Small Model Prompt" from Settings → Features → Prompt Library
2. View the prompt selection in the logs to confirm which prompt template is being used