### PR TITLE
#1561: Permit bedrockOptions in AWS_BEDROCK_CONFIG

### DIFF
--- a/app/lib/modules/llm/providers/amazon-bedrock.ts
+++ b/app/lib/modules/llm/providers/amazon-bedrock.ts
@@ -2,14 +2,7 @@ import { BaseProvider } from '~/lib/modules/llm/base-provider';
 import type { ModelInfo } from '~/lib/modules/llm/types';
 import type { LanguageModelV1 } from 'ai';
 import type { IProviderSetting } from '~/types/model';
-import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
-
-interface AWSBedRockConfig {
-  region: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken?: string;
-}
+import { createAmazonBedrock, type AmazonBedrockProviderSettings } from '@ai-sdk/amazon-bedrock';
 
 export default class AmazonBedrockProvider extends BaseProvider {
   name = 'AmazonBedrock';
@@ -64,8 +57,8 @@ export default class AmazonBedrockProvider extends BaseProvider {
     },
   ];
 
-  private _parseAndValidateConfig(apiKey: string): AWSBedRockConfig {
-    let parsedConfig: AWSBedRockConfig;
+  private _parseAndValidateConfig(apiKey: string): AmazonBedrockProviderSettings {
+    let parsedConfig: AmazonBedrockProviderSettings;
 
     try {
       parsedConfig = JSON.parse(apiKey);
@@ -75,7 +68,7 @@ export default class AmazonBedrockProvider extends BaseProvider {
       );
     }
 
-    const { region, accessKeyId, secretAccessKey, sessionToken } = parsedConfig;
+    const { region, accessKeyId, secretAccessKey, sessionToken, bedrockOptions } = parsedConfig;
 
     if (!region || !accessKeyId || !secretAccessKey) {
       throw new Error(
@@ -88,6 +81,7 @@ export default class AmazonBedrockProvider extends BaseProvider {
       accessKeyId,
       secretAccessKey,
       ...(sessionToken && { sessionToken }),
+      ...(bedrockOptions && { bedrockOptions }),
     };
   }
 


### PR DESCRIPTION
Closes https://github.com/stackblitz-labs/bolt.diy/issues/1561

Though I recommend y'all completely remove the pre-checks. Just catch a failed JSON parse then hand it off directly to Vercel to handle the errors anyway. Worked w/ endpoint override. And actually because setting bedrockOptions discards the others, it picked up my Env vars too! Works great as is tho!

```
AWS_BEDROCK_CONFIG={ ... , "bedrockOptions": { "endpoint": "https://vpce-0570555cc737321c1-9zvrep68.bedrock-runtime.us-east-1.vpce.amazonaws.com" } }
```