### PR TITLE
fix: updated list of google gemini models

### DIFF
--- a/app/lib/modules/llm/providers/google.ts
+++ b/app/lib/modules/llm/providers/google.ts
@@ -20,6 +20,12 @@ export default class GoogleProvider extends BaseProvider {
       provider: 'Google',
       maxTokenAllowed: 65536,
     },
+    {
+      name: 'gemini-2.5-pro-exp-03-25"',
+      label: 'Gemini 2.5 Pro Experimental 03-25',
+      provider: 'Google',
+      maxTokenAllowed: 65536,
+    },
     { name: 'gemini-2.0-flash-exp', label: 'Gemini 2.0 Flash', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-flash-002', label: 'Gemini 1.5 Flash-002', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash-8b', provider: 'Google', maxTokenAllowed: 8192 },

--- a/app/lib/modules/llm/providers/google.ts
+++ b/app/lib/modules/llm/providers/google.ts
@@ -31,7 +31,6 @@ export default class GoogleProvider extends BaseProvider {
     { name: 'gemini-1.5-flash-8b', label: 'Gemini 1.5 Flash-8b', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-pro-latest', label: 'Gemini 1.5 Pro', provider: 'Google', maxTokenAllowed: 8192 },
     { name: 'gemini-1.5-pro-002', label: 'Gemini 1.5 Pro-002', provider: 'Google', maxTokenAllowed: 8192 },
-    { name: 'gemini-exp-1206', label: 'Gemini exp-1206', provider: 'Google', maxTokenAllowed: 8192 },
   ];
 
   async getDynamicModels(


### PR DESCRIPTION
very simple pull request, I just added the new (amazing) Gemini model and removed exp-1206 since it was removed months ago. 

