### PR TITLE
fix: update stream-text.ts

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -157,45 +157,122 @@ ${props.summary}
   const originalMessages = [...messages];
   const hasMultimodalContent = originalMessages.some((msg) => Array.isArray(msg.content));
 
-  if (hasMultimodalContent) {
-    /*
-     * For multimodal content, we need to preserve the original array structure
-     * but make sure the roles are valid
-     */
-    const multimodalMessages = originalMessages.map((msg) => ({
-      role: msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant' ? msg.role : 'user',
-      content: msg.content,
-    }));
+  try {
+    if (hasMultimodalContent) {
+      /*
+       * For multimodal content, we need to preserve the original array structure
+       * but make sure the roles are valid and content items are properly formatted
+       */
+      const multimodalMessages = originalMessages.map((msg) => ({
+        role: msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant' ? msg.role : 'user',
+        content: Array.isArray(msg.content)
+          ? msg.content.map((item) => {
+              // Ensure each content item has the correct format
+              if (typeof item === 'string') {
+                return { type: 'text', text: item };
+              }
 
-    return await _streamText({
-      model: provider.getModelInstance({
-        model: modelDetails.name,
-        serverEnv,
-        apiKeys,
-        providerSettings,
-      }),
-      system: systemPrompt,
-      maxTokens: dynamicMaxTokens,
-      messages: multimodalMessages as any,
-      ...options,
-    });
-  } else {
-    const normalizedTextMessages = processedMessages.map((msg) => ({
-      role: msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant' ? msg.role : 'user',
-      content: typeof msg.content === 'string' ? msg.content : String(msg.content),
-    }));
+              if (item && typeof item === 'object') {
+                if (item.type === 'image' && item.image) {
+                  return { type: 'image', image: item.image };
+                }
 
-    return await _streamText({
-      model: provider.getModelInstance({
-        model: modelDetails.name,
-        serverEnv,
-        apiKeys,
-        providerSettings,
-      }),
-      system: systemPrompt,
-      maxTokens: dynamicMaxTokens,
-      messages: convertToCoreMessages(normalizedTextMessages),
-      ...options,
-    });
+                if (item.type === 'text') {
+                  return { type: 'text', text: item.text || '' };
+                }
+              }
+
+              // Default fallback for unknown formats
+              return { type: 'text', text: String(item || '') };
+            })
+          : [{ type: 'text', text: typeof msg.content === 'string' ? msg.content : String(msg.content || '') }],
+      }));
+
+      return await _streamText({
+        model: provider.getModelInstance({
+          model: modelDetails.name,
+          serverEnv,
+          apiKeys,
+          providerSettings,
+        }),
+        system: systemPrompt,
+        maxTokens: dynamicMaxTokens,
+        messages: multimodalMessages as any,
+        ...options,
+      });
+    } else {
+      // For non-multimodal content, we use the standard approach
+      const normalizedTextMessages = processedMessages.map((msg) => ({
+        role: msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant' ? msg.role : 'user',
+        content: typeof msg.content === 'string' ? msg.content : String(msg.content || ''),
+      }));
+
+      return await _streamText({
+        model: provider.getModelInstance({
+          model: modelDetails.name,
+          serverEnv,
+          apiKeys,
+          providerSettings,
+        }),
+        system: systemPrompt,
+        maxTokens: dynamicMaxTokens,
+        messages: convertToCoreMessages(normalizedTextMessages),
+        ...options,
+      });
+    }
+  } catch (error: any) {
+    // Special handling for format errors
+    if (error.message && error.message.includes('messages must be an array of CoreMessage or UIMessage')) {
+      logger.warn('Message format error detected, attempting recovery with explicit formatting...');
+
+      // Create properly formatted messages for all cases as a last resort
+      const fallbackMessages = processedMessages.map((msg) => {
+        // Determine text content with careful type handling
+        let textContent = '';
+
+        if (typeof msg.content === 'string') {
+          textContent = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          // Handle array content safely
+          const contentArray = msg.content as any[];
+          textContent = contentArray
+            .map((contentItem) =>
+              typeof contentItem === 'string'
+                ? contentItem
+                : contentItem?.text || contentItem?.image || String(contentItem || ''),
+            )
+            .join(' ');
+        } else {
+          textContent = String(msg.content || '');
+        }
+
+        return {
+          role: msg.role === 'system' || msg.role === 'user' || msg.role === 'assistant' ? msg.role : 'user',
+          content: [
+            {
+              type: 'text',
+              text: textContent,
+            },
+          ],
+        };
+      });
+
+      // Try one more time with the fallback format
+      return await _streamText({
+        model: provider.getModelInstance({
+          model: modelDetails.name,
+          serverEnv,
+          apiKeys,
+          providerSettings,
+        }),
+        system: systemPrompt,
+        maxTokens: dynamicMaxTokens,
+        messages: fallbackMessages as any,
+        ...options,
+      });
+    }
+
+    // If it's not a format error, re-throw the original error
+    throw error;
   }
 }


### PR DESCRIPTION
This is a bugfix for : https://github.com/stackblitz-labs/bolt.diy/issues/1575

## Fix: Message Format Compatibility Error in LLM Streaming

### Issue
Fixed a critical error where chat initialization would fail with:
`Invalid prompt: messages must be an array of CoreMessage or UIMessage`

This occurred when:
- Processing XML template selections
- Handling multimodal content (text + images)
- Receiving message content without proper type formatting

### Solution
- Added validation for multimodal content format
- Ensured all content items have required `type` field
- Implemented error recovery to handle malformed messages
- Added safeguards against null/undefined values
- Created fallback mechanism for edge cases

These changes ensure compatibility with the Vercel AI SDK requirements while maintaining existing functionality.