### PR TITLE
feat: bulk delete chats from sidebar

### DIFF
--- a/app/components/@settings/tabs/connections/ConnectionsTab.tsx
+++ b/app/components/@settings/tabs/connections/ConnectionsTab.tsx
@@ -148,6 +148,48 @@ export default function ConnectionsTab() {
         </div>
       </motion.div>
 
+      {/* Cloudflare Deployment Note - Highly visible */}
+      <motion.div
+        className="bg-gradient-to-r from-blue-50 to-blue-100 dark:from-blue-950/40 dark:to-blue-900/30 border border-blue-200 dark:border-blue-800/50 rounded-lg shadow-sm p-4 mb-6"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3 }}
+      >
+        <div className="flex items-center gap-2 mb-2 text-blue-700 dark:text-blue-400">
+          <div className="i-ph:cloud-bold w-5 h-5" />
+          <h3 className="text-base font-medium">Using Cloudflare Pages?</h3>
+        </div>
+        <p className="text-sm text-blue-700 dark:text-blue-300 mb-2">
+          If you're experiencing GitHub connection issues (500 errors) on Cloudflare Pages deployments, you need to
+          configure environment variables in your Cloudflare dashboard:
+        </p>
+        <div className="bg-white/80 dark:bg-slate-900/60 rounded-md p-3 text-sm border border-blue-200 dark:border-blue-800/50">
+          <ol className="list-decimal list-inside pl-2 text-blue-700 dark:text-blue-300 space-y-2">
+            <li>
+              Go to <strong>Cloudflare Pages dashboard → Your project → Settings → Environment variables</strong>
+            </li>
+            <li>
+              Add <strong>both</strong> of these secrets (Production environment):
+              <ul className="list-disc list-inside pl-4 mt-1 mb-1">
+                <li>
+                  <code className="px-1 py-0.5 bg-blue-100 dark:bg-blue-800/40 rounded">GITHUB_ACCESS_TOKEN</code>{' '}
+                  (server-side API calls)
+                </li>
+                <li>
+                  <code className="px-1 py-0.5 bg-blue-100 dark:bg-blue-800/40 rounded">VITE_GITHUB_ACCESS_TOKEN</code>{' '}
+                  (client-side access)
+                </li>
+              </ul>
+            </li>
+            <li>
+              Add <code className="px-1 py-0.5 bg-blue-100 dark:bg-blue-800/40 rounded">VITE_GITHUB_TOKEN_TYPE</code> if
+              using fine-grained tokens
+            </li>
+            <li>Deploy a fresh build after adding these variables</li>
+          </ol>
+        </div>
+      </motion.div>
+
       <div className="grid grid-cols-1 gap-6">
         <Suspense fallback={<LoadingFallback />}>
           <GitHubConnection />

--- a/app/components/sidebar/HistoryItem.tsx
+++ b/app/components/sidebar/HistoryItem.tsx
@@ -1,10 +1,9 @@
 import { useParams } from '@remix-run/react';
 import { classNames } from '~/utils/classNames';
-import * as Dialog from '@radix-ui/react-dialog';
 import { type ChatHistoryItem } from '~/lib/persistence';
 import WithTooltip from '~/components/ui/Tooltip';
 import { useEditChatDescription } from '~/lib/hooks';
-import { forwardRef, type ForwardedRef } from 'react';
+import { forwardRef, type ForwardedRef, useCallback } from 'react';
 import { Checkbox } from '~/components/ui/Checkbox';
 
 interface HistoryItemProps {
@@ -36,19 +35,51 @@ export function HistoryItem({
       syncWithGlobalStore: isActiveChat,
     });
 
+  const handleItemClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (selectionMode) {
+        e.preventDefault();
+        e.stopPropagation();
+        console.log('Item clicked in selection mode:', item.id);
+        onToggleSelection?.(item.id);
+      }
+    },
+    [selectionMode, item.id, onToggleSelection],
+  );
+
+  const handleCheckboxChange = useCallback(() => {
+    console.log('Checkbox changed for item:', item.id);
+    onToggleSelection?.(item.id);
+  }, [item.id, onToggleSelection]);
+
+  const handleDeleteClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      console.log('Delete button clicked for item:', item.id);
+
+      if (onDelete) {
+        onDelete(event as unknown as React.UIEvent);
+      }
+    },
+    [onDelete, item.id],
+  );
+
   return (
     <div
       className={classNames(
         'group rounded-lg text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50/80 dark:hover:bg-gray-800/30 overflow-hidden flex justify-between items-center px-3 py-2 transition-colors',
         { 'text-gray-900 dark:text-white bg-gray-50/80 dark:bg-gray-800/30': isActiveChat },
+        { 'cursor-pointer': selectionMode },
       )}
+      onClick={selectionMode ? handleItemClick : undefined}
     >
       {selectionMode && (
-        <div className="flex items-center mr-2" onClick={(e) => e.preventDefault()}>
+        <div className="flex items-center mr-2" onClick={(e) => e.stopPropagation()}>
           <Checkbox
             id={`select-${item.id}`}
             checked={isSelected}
-            onCheckedChange={() => onToggleSelection?.(item.id)}
+            onCheckedChange={handleCheckboxChange}
             className="h-4 w-4"
           />
         </div>
@@ -72,7 +103,11 @@ export function HistoryItem({
           />
         </form>
       ) : (
-        <a href={`/chat/${item.urlId}`} className="flex w-full relative truncate block">
+        <a
+          href={`/chat/${item.urlId}`}
+          className="flex w-full relative truncate block"
+          onClick={selectionMode ? handleItemClick : undefined}
+        >
           <WithTooltip tooltip={currentDescription}>
             <span className="truncate pr-24">{currentDescription}</span>
           </WithTooltip>
@@ -94,7 +129,10 @@ export function HistoryItem({
                 <ChatActionButton
                   toolTipContent="Duplicate"
                   icon="i-ph:copy h-4 w-4"
-                  onClick={() => onDuplicate?.(item.id)}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onDuplicate?.(item.id);
+                  }}
                 />
               )}
               <ChatActionButton
@@ -105,17 +143,12 @@ export function HistoryItem({
                   toggleEditMode();
                 }}
               />
-              <Dialog.Trigger asChild>
-                <ChatActionButton
-                  toolTipContent="Delete"
-                  icon="i-ph:trash h-4 w-4"
-                  className="hover:text-red-500 dark:hover:text-red-400"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    onDelete?.(event);
-                  }}
-                />
-              </Dialog.Trigger>
+              <ChatActionButton
+                toolTipContent="Delete"
+                icon="i-ph:trash h-4 w-4"
+                className="hover:text-red-500 dark:hover:text-red-400"
+                onClick={handleDeleteClick}
+              />
             </div>
           </div>
         </a>

--- a/app/components/sidebar/HistoryItem.tsx
+++ b/app/components/sidebar/HistoryItem.tsx
@@ -5,15 +5,27 @@ import { type ChatHistoryItem } from '~/lib/persistence';
 import WithTooltip from '~/components/ui/Tooltip';
 import { useEditChatDescription } from '~/lib/hooks';
 import { forwardRef, type ForwardedRef } from 'react';
+import { Checkbox } from '~/components/ui/Checkbox';
 
 interface HistoryItemProps {
   item: ChatHistoryItem;
   onDelete?: (event: React.UIEvent) => void;
   onDuplicate?: (id: string) => void;
   exportChat: (id?: string) => void;
+  selectionMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelection?: (id: string) => void;
 }
 
-export function HistoryItem({ item, onDelete, onDuplicate, exportChat }: HistoryItemProps) {
+export function HistoryItem({
+  item,
+  onDelete,
+  onDuplicate,
+  exportChat,
+  selectionMode = false,
+  isSelected = false,
+  onToggleSelection,
+}: HistoryItemProps) {
   const { id: urlId } = useParams();
   const isActiveChat = urlId === item.urlId;
 
@@ -31,6 +43,17 @@ export function HistoryItem({ item, onDelete, onDuplicate, exportChat }: History
         { 'text-gray-900 dark:text-white bg-gray-50/80 dark:bg-gray-800/30': isActiveChat },
       )}
     >
+      {selectionMode && (
+        <div className="flex items-center mr-2" onClick={(e) => e.preventDefault()}>
+          <Checkbox
+            id={`select-${item.id}`}
+            checked={isSelected}
+            onCheckedChange={() => onToggleSelection?.(item.id)}
+            className="h-4 w-4"
+          />
+        </div>
+      )}
+
       {editing ? (
         <form onSubmit={handleSubmit} className="flex-1 flex items-center gap-2">
           <input
@@ -55,8 +78,7 @@ export function HistoryItem({ item, onDelete, onDuplicate, exportChat }: History
           </WithTooltip>
           <div
             className={classNames(
-              'absolute right-0 top-0 bottom-0 flex items-center bg-white dark:bg-gray-950 group-hover:bg-gray-50/80 dark:group-hover:bg-gray-800/30 px-2',
-              { 'bg-gray-50/80 dark:bg-gray-800/30': isActiveChat },
+              'absolute right-0 top-0 bottom-0 flex items-center bg-transparent px-2 transition-colors',
             )}
           >
             <div className="flex items-center gap-2.5 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -87,7 +109,7 @@ export function HistoryItem({ item, onDelete, onDuplicate, exportChat }: History
                 <ChatActionButton
                   toolTipContent="Delete"
                   icon="i-ph:trash h-4 w-4"
-                  className="hover:text-red-500"
+                  className="hover:text-red-500 dark:hover:text-red-400"
                   onClick={(event) => {
                     event.preventDefault();
                     onDelete?.(event);

--- a/app/components/ui/Checkbox.tsx
+++ b/app/components/ui/Checkbox.tsx
@@ -10,13 +10,20 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={classNames(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:focus:ring-purple-400 dark:focus:ring-offset-gray-900',
+      'peer h-4 w-4 shrink-0 rounded-sm border transition-colors',
+      'bg-transparent dark:bg-transparent',
+      'border-gray-400 dark:border-gray-600',
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:ring-purple-500 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-purple-500 dark:data-[state=checked]:bg-purple-500',
+      'data-[state=checked]:border-purple-500 dark:data-[state=checked]:border-purple-500',
+      'data-[state=checked]:text-white',
       className,
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className="flex items-center justify-center">
-      <Check className="h-3 w-3 text-purple-500 dark:text-purple-400" />
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3 w-3" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));


### PR DESCRIPTION
This is new feature request from : https://github.com/stackblitz-labs/bolt.diy/issues/1585

feat(sidebar): Implement bulk chat deletion

Adds the ability for users to select multiple chats from the history sidebar and delete them in bulk.

**Key Changes:**

*   **Selection Mode:** Introduced a selection mode toggled by a dedicated button next to "Start new chat".
*   **Checkboxes:** Added checkboxes to each `HistoryItem` visible only when selection mode is active.
*   **Bulk Actions:** Added "Select All" / "Deselect All" and "Delete Selected" buttons (`Button` component with `ghost` variant) that appear above the chat list in selection mode.
*   **Confirmation Dialog:** Implemented a confirmation dialog (`Dialog` component) to prevent accidental deletion, listing the chats selected for removal.
*   **Deletion Logic:** Updated `Menu.client.tsx` to handle the selection state and perform bulk deletion using `deleteById` from persistence layer.
*   **Styling:** Ensured all new UI elements (`Checkbox`, `Button`) adhere to the existing project design system and support both light and dark themes using appropriate CSS classes and UnoCSS icons (`i-ph:` prefix).
*   **Refinement:** Replaced initial plain `<button>` elements with the project's `Button` component for consistency. Fixed incorrect icon prefixes.
<br></br>
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/e6ce2d7c-8e59-4463-817e-f90314a9180f" />
