### PR TITLE
fix: make diff button consistent with other toolbar buttons

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -90,8 +90,8 @@ const FileModifiedDropdown = memo(
         <Popover className="relative">
           {({ open }: { open: boolean }) => (
             <>
-              <Popover.Button className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-bolt-elements-background-depth-2 hover:bg-bolt-elements-background-depth-3 transition-colors text-bolt-elements-textPrimary border border-bolt-elements-borderColor">
-                <span className="font-medium">File Changes</span>
+              <Popover.Button className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-bolt-elements-background-depth-2 hover:bg-bolt-elements-background-depth-3 transition-colors text-bolt-elements-item-contentDefault">
+                <span>File Changes</span>
                 {hasChanges && (
                   <span className="w-5 h-5 rounded-full bg-accent-500/20 text-accent-500 text-xs flex items-center justify-center border border-accent-500/30">
                     {modifiedFiles.length}


### PR DESCRIPTION
Changed the `File Changes` button on the `Diff` tab to have a consistent style with the buttons on the `Code` tab. The larger font size of `File Changes` and border on the button caused the header to have an inconsistent height, which is now fixed.

`Code` tab:
<img width="803" alt="Screenshot 2025-04-04 at 7 12 48 PM" src="https://github.com/user-attachments/assets/edd374eb-3527-4b86-a041-70a9bfdc24cd" />

Changed to:
<img width="805" alt="Screenshot 2025-04-04 at 7 12 53 PM" src="https://github.com/user-attachments/assets/e5b01312-59a8-4657-b0bb-eeb7d2c1e4f9" />

Previously:
<img width="790" alt="Screenshot 2025-04-04 at 7 15 06 PM" src="https://github.com/user-attachments/assets/6ea23c74-12df-48bd-8305-3298c38519be" />
