### PR TITLE
refactor: remove success toast and prioritize public domain URL

### DIFF
--- a/app/components/deploy/NetlifyDeploy.client.tsx
+++ b/app/components/deploy/NetlifyDeploy.client.tsx
@@ -224,20 +224,6 @@ export function useNetlifyDeploy() {
         source: 'netlify',
       });
 
-      toast.success(
-        <div>
-          Deployed successfully!{' '}
-          <a
-            href={deploymentStatus.ssl_url || deploymentStatus.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            View site
-          </a>
-        </div>,
-      );
-
       return true;
     } catch (error) {
       console.error('Deploy error:', error);

--- a/app/components/deploy/VercelDeploy.client.tsx
+++ b/app/components/deploy/VercelDeploy.client.tsx
@@ -174,15 +174,6 @@ export function useVercelDeploy() {
         source: 'vercel',
       });
 
-      toast.success(
-        <div>
-          Deployed successfully to Vercel!{' '}
-          <a href={data.deploy.url} target="_blank" rel="noopener noreferrer" className="underline">
-            View site
-          </a>
-        </div>,
-      );
-
       return true;
     } catch (err) {
       console.error('Vercel deploy error:', err);

--- a/app/routes/api.vercel-deploy.ts
+++ b/app/routes/api.vercel-deploy.ts
@@ -237,7 +237,9 @@ export async function action({ request }: ActionFunctionArgs) {
       deploy: {
         id: deployData.id,
         state: deploymentState,
-        url: deploymentUrl || projectInfo.url,
+
+        // Return public domain as deploy URL and private domain as fallback.
+        url: projectInfo.url || deploymentUrl,
       },
       project: projectInfo,
     });


### PR DESCRIPTION
Remove redundant success toast messages from Vercel and Netlify deploy components. Additionally, prioritize the public domain URL over the private domain in the Vercel deploy action for consistency and clarity.