### PR TITLE
Fix disk full issue when npm install runs

### DIFF
--- a/app/lib/stores/previews.ts
+++ b/app/lib/stores/previews.ts
@@ -154,7 +154,7 @@ export class PreviewsStore {
     try {
       // Watch for file changes
       webcontainer.internal.watchPaths(
-        { include: ['**/*'], exclude: ['**/node_modules', '.git'], includeContent: true },
+        { include: ['**/*'], exclude: ['**/node_modules', '.git'], includeContent: false },
         async (_events) => {
           const previews = this.previews.get();
 


### PR DESCRIPTION
When `npm install` command runs on the terminal. The system use too much memory and crash the browser.

Possible cause of issue:
Every time a file changes, the entire content of that file is stored in memory, because of true flag.