### PR TITLE
fix: disk full on npm i

### DIFF
--- a/app/lib/stores/previews.ts
+++ b/app/lib/stores/previews.ts
@@ -154,7 +154,7 @@ export class PreviewsStore {
     try {
       // Watch for file changes
       webcontainer.internal.watchPaths(
-        { include: ['**/*'], exclude: ['**/node_modules', '.git'], includeContent: true },
+        { include: ['**/*'], exclude: ['**/node_modules', '.git'], includeContent: false },
         async (_events) => {
           const previews = this.previews.get();
 


### PR DESCRIPTION
The problem is the includeContent: true parameter. This option tells the watcher to include the full content of every file in the watch events. This means:

Every time a file changes, the entire content of that file is stored in memory
If you have many files or large files, this can consume a significant amount of memory
This data might be written to disk for logging or caching purposes
Over time, this can fill up your disk, especially if there are frequent file changes