### PR TITLE
fix: optimize file watch paths for preview updates and fix npm crashes

### DIFF
--- a/app/lib/stores/previews.ts
+++ b/app/lib/stores/previews.ts
@@ -154,7 +154,11 @@ export class PreviewsStore {
     try {
       // Watch for file changes
       webcontainer.internal.watchPaths(
-        { include: ['**/*'], exclude: ['**/node_modules', '.git'], includeContent: true },
+        {
+          // Only watch specific file types that affect the preview
+          include: ['**/*.html', '**/*.css', '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '**/*.json'],
+          exclude: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**', '**/coverage/**'],
+        },
         async (_events) => {
           const previews = this.previews.get();
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/react-beautiful-dnd": "^13.1.8",
     "@uiw/codemirror-theme-vscode": "^4.23.6",
     "@unocss/reset": "^0.61.9",
-    "@webcontainer/api": "1.3.0-internal.10",
+    "@webcontainer/api": "1.5.3-internal.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,8 +171,8 @@ importers:
         specifier: ^0.61.9
         version: 0.61.9
       '@webcontainer/api':
-        specifier: 1.3.0-internal.10
-        version: 1.3.0-internal.10
+        specifier: 1.5.3-internal.2
+        version: 1.5.3-internal.2
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -3501,8 +3501,8 @@ packages:
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
-  '@webcontainer/api@1.3.0-internal.10':
-    resolution: {integrity: sha512-iuqjuDX2uADiJMYZok7+tJqVCJYZ+tU2NwVtxlvakRWSSmIFBGrJ38pD0C5igaOnBV8C9kGDjCE6B03SvLtN4Q==}
+  '@webcontainer/api@1.5.3-internal.2':
+    resolution: {integrity: sha512-PNel1OQJlibs92zw5ekSeJLxYKXBk/AMnIQ9rJ/5cqJwjFlR242PlpCGJRghiZwQf4jq2p/ntvHyj7P+MHXqpg==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -11624,7 +11624,7 @@ snapshots:
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
-  '@webcontainer/api@1.3.0-internal.10': {}
+  '@webcontainer/api@1.5.3-internal.2': {}
 
   '@xmldom/xmldom@0.8.10': {}
 


### PR DESCRIPTION
Fix a critical bug where npm actions fail/crash due to all file contents being included in watcher.

Update the file watch paths in the previews store to only include relevant file types (e.g., HTML, CSS, JS) and exclude unnecessary directories (e.g., node_modules, dist). This reduces unnecessary file system events and improves performance.

Also, update the @webcontainer/api dependency to the latest internal version for enhanced functionality, node20 and upcoming features.