### PR TITLE
chore: add pnpm store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.pnpm-store
 
 .vscode/*
 .vscode/launch.json


### PR DESCRIPTION
After following the readme file to run the application we found the .pnpm-store inside the project root with 10K changes

![image](https://github.com/user-attachments/assets/91b74c80-0a16-4cbb-b5fb-b78de8c41889)

This commits just adds pnpm store to gitignore so we don`t bother with that :)

![image](https://github.com/user-attachments/assets/9e694239-0e4e-4a09-88d2-2e4d3ce12a24)
