### PR TITLE
ci: remove macOS code signing credentials from workflow

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -67,11 +67,6 @@ jobs:
       - name: Build Electron app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,7 +21,7 @@ mac:
   icon: assets/icons/icon.icns
   target:
     - dmg
-  identity: "Xinzhe Wang (RDQSC33B2X)"
+  identity: null
   category: "public.app-category.developer-tools"
   type: "distribution"
   hardenedRuntime: true


### PR DESCRIPTION
The code signing credentials for macOS were removed from the GitHub Actions workflow and the identity field in the electron-builder.yml was set to null. This change was made to include unsigned .dmg releases