### PR TITLE
fix: invalid line number error in search functionality

### DIFF
--- a/app/components/editor/codemirror/CodeMirrorEditor.tsx
+++ b/app/components/editor/codemirror/CodeMirrorEditor.tsx
@@ -169,12 +169,25 @@ export const CodeMirrorEditor = memo(
       if (typeof doc.scroll?.line === 'number') {
         const line = doc.scroll.line;
         const column = doc.scroll.column ?? 0;
-        const linePos = viewRef.current.state.doc.line(line + 1).from + column;
-        viewRef.current.dispatch({
-          selection: { anchor: linePos },
-          scrollIntoView: true,
-        });
-        viewRef.current.focus();
+
+        try {
+          // Check if the line number is valid for the current document
+          const totalLines = viewRef.current.state.doc.lines;
+
+          // Only proceed if the line number is within the document's range
+          if (line < totalLines) {
+            const linePos = viewRef.current.state.doc.line(line + 1).from + column;
+            viewRef.current.dispatch({
+              selection: { anchor: linePos },
+              scrollIntoView: true,
+            });
+            viewRef.current.focus();
+          } else {
+            logger.warn(`Invalid line number ${line + 1} in ${totalLines}-line document`);
+          }
+        } catch (error) {
+          logger.error('Error scrolling to line:', error);
+        }
       } else if (typeof doc.scroll?.top === 'number' || typeof doc.scroll?.left === 'number') {
         viewRef.current.scrollDOM.scrollTo(doc.scroll.left ?? 0, doc.scroll.top ?? 0);
       }
@@ -441,12 +454,25 @@ function setEditorDocument(
       if (typeof doc.scroll?.line === 'number') {
         const line = doc.scroll.line;
         const column = doc.scroll.column ?? 0;
-        const linePos = view.state.doc.line(line + 1).from + column;
-        view.dispatch({
-          selection: { anchor: linePos },
-          scrollIntoView: true,
-        });
-        view.focus();
+
+        try {
+          // Check if the line number is valid for the current document
+          const totalLines = view.state.doc.lines;
+
+          // Only proceed if the line number is within the document's range
+          if (line < totalLines) {
+            const linePos = view.state.doc.line(line + 1).from + column;
+            view.dispatch({
+              selection: { anchor: linePos },
+              scrollIntoView: true,
+            });
+            view.focus();
+          } else {
+            logger.warn(`Invalid line number ${line + 1} in ${totalLines}-line document`);
+          }
+        } catch (error) {
+          logger.error('Error scrolling to line:', error);
+        }
 
         return;
       }

--- a/app/components/workbench/Search.tsx
+++ b/app/components/workbench/Search.tsx
@@ -167,7 +167,14 @@ export function Search() {
 
   const handleResultClick = (filePath: string, line?: number) => {
     workbenchStore.setSelectedFile(filePath);
-    workbenchStore.setCurrentDocumentScrollPosition({ line, column: 0 });
+
+    /*
+     * Adjust line number to be 0-based if it's defined
+     * The search results use 1-based line numbers, but CodeMirrorEditor expects 0-based
+     */
+    const adjustedLine = typeof line === 'number' ? Math.max(0, line - 1) : undefined;
+
+    workbenchStore.setCurrentDocumentScrollPosition({ line: adjustedLine, column: 0 });
   };
 
   return (


### PR DESCRIPTION
# Fix Invalid Line Number Error in Search Functionality

## Problem
When clicking on search results, the application would crash with an error: "Invalid line number 11 in 4-line document". This happened because the search results contained line numbers that were outside the range of the actual document.

## Solution
1. Added safety checks in `CodeMirrorEditor.tsx` to verify that line numbers are valid before trying to navigate to them
2. Added error handling to prevent crashes when invalid line numbers are encountered
3. Adjusted line numbers in the Search component from 1-based (search API) to 0-based (editor expects)

The key improvement was adding validation to ensure we never try to navigate to a line that doesn't exist in the document, which prevents the application from crashing.