### PR TITLE
Update docs to point to Electron installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,17 @@ If you're new to installing software from GitHub, don't worry! If you encounter 
 
 Let's get you up and running with the stable version of Bolt.DIY!
 
-## Quick Download
+## Quick Installation
 
 [![Download Latest Release](https://img.shields.io/github/v/release/stackblitz-labs/bolt.diy?label=Download%20Bolt&sort=semver)](https://github.com/stackblitz-labs/bolt.diy/releases/latest) ← Click here to go the the latest release version!
 
-- Next **click source.zip**
+- Download the binary for your platform
+- Note: For macOS, if you get the error "This app is damaged", run ```xattr -cr /path/to/Bolt.app```
 
-## Prerequisites
+## Manual installation
 
-Before you begin, you'll need to install two important pieces of software:
 
-### Install Node.js
+### Option 1: Node.js
 
 Node.js is required to run the application.
 


### PR DESCRIPTION
The Electron installation should be the default quick install method as it requires the least amount of setup. Below that I changed the language to be a little more clear since there was an option 2 but not an option 1. Also, I included the terminal script to fix the "this application is damaged" issue on macOS. To fix this, I believe the Mac app has to be notarized which it wasn't when I tried.