### PR TITLE
fix: increase Node.js memory limit in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV WRANGLER_SEND_METRICS=false \
 RUN mkdir -p /root/.config/.wrangler && \
     echo '{"enabled":false}' > /root/.config/.wrangler/metrics.json
 
-RUN pnpm run build
+RUN node --max-old-space-size=4096 node_modules/.bin/pnpm run build
 
 CMD [ "pnpm", "run", "dockerstart"]
 


### PR DESCRIPTION
The Docker build process was failing with an out-of-memory error during the `pnpm run build` step in the `bolt-ai-production` stage.

This commit increases the memory available to Node.js by modifying the build command to include the `--max-old-space-size=4096` flag. This provides 4GB of memory to the Node.js process, which should be sufficient to complete the build.