### PR TITLE
fix: enforce max response segments

### DIFF
--- a/app/components/chat/ProgressCompilation.tsx
+++ b/app/components/chat/ProgressCompilation.tsx
@@ -100,6 +100,8 @@ const ProgressItem = ({ progress }: { progress: ProgressAnnotation }) => {
             <div className="i-svg-spinners:90-ring-with-bg"></div>
           ) : progress.status === 'complete' ? (
             <div className="i-ph:check"></div>
+          ) : progress.status === 'error' ? (
+            <div className="i-ph:warning"></div>
           ) : null}
         </div>
         {/* {x.label} */}

--- a/app/types/context.ts
+++ b/app/types/context.ts
@@ -12,7 +12,13 @@ export type ContextAnnotation =
 export type ProgressAnnotation = {
   type: 'progress';
   label: string;
-  status: 'in-progress' | 'complete';
+  status: 'in-progress' | 'complete' | 'error';
   order: number;
+  message: string;
+};
+
+export type DataStreamError = {
+  type: 'error';
+  id: string;
   message: string;
 };


### PR DESCRIPTION
The limit on MAX_RESPONSE_SEGMENTS was being ignored. 

The logic for determining the number of segments depended on the number of times the `SwitchableStream` did a switch, but the stream is never used. Maybe that was removed in a refactor?

Now it keeps a local `responseSegments` variable around that keeps track of the number of times `streamText` was called.

Of course nothing is ever that easy. In the previous version, an error was thrown in the `onFinish` callback. Unfortunately that causes the entire node server to shut down in dev.

In this PR, a new data packet with `type="error"` is sent down the datastream and then an alert is shown in `Chat.client.ts`. The client code is a little more complex than I'd like because the `data` field returned from `useChat` will resurrect data, even if it's removed with a `setData`. So I just gave each error an `id` and keep track of the ids that have already been alerted on. Those won't grow forever, because they're removed when we clear the data in `onFinish`.

Tested everything locally by setting `maxTokens` to 50 in `stream-text.ts`.

Here's what it looks like when you hit the error. The progress bar right above the chat input shows an error and there is an error toast:

<img width="1346" alt="Screenshot 2025-05-21 at 1 05 58 PM" src="https://github.com/user-attachments/assets/78ec53d3-36aa-42c9-90cc-67c4722314e4" />


