### PR TITLE
fix: fix prompt continuation

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -531,16 +531,18 @@ export const ChatImpl = memo(
         description={description}
         importChat={importChat}
         exportChat={exportChat}
-        messages={messages.map((message, i) => {
-          if (message.role === 'user') {
-            return message;
-          }
+        messages={messages
+          .filter((message, i) => (message.role === 'assistant' ? parsedMessages[i] : true))
+          .map((message, i) => {
+            if (message.role === 'user') {
+              return message;
+            }
 
-          return {
-            ...message,
-            content: parsedMessages[i] || '',
-          };
-        })}
+            return {
+              ...message,
+              content: parsedMessages[i] || '',
+            };
+          })}
         enhancePrompt={() => {
           enhancePrompt(
             input,

--- a/app/lib/common/prompts/new-prompt.ts
+++ b/app/lib/common/prompts/new-prompt.ts
@@ -1,6 +1,5 @@
 import { WORK_DIR } from '~/utils/constants';
 import { allowedHTMLElements } from '~/utils/markdown';
-import { stripIndents } from '~/utils/stripIndent';
 
 export const getFineTunedPrompt = (
   cwd: string = WORK_DIR,
@@ -695,7 +694,12 @@ npm run dev
   </example>
 </examples>`;
 
-export const CONTINUE_PROMPT = stripIndents`
-  Continue your prior response. IMPORTANT: Immediately begin from where you left off without any interruptions.
-  Do not repeat any content, including artifact and action tags.
-`;
+export const CONTINUE_PROMPT = `Continue your prior response.
+Important: continue your last message without any interruptions, even if you're in the middle of a thought. You are continuing a document that will be re-assembled later. Never repeat any text that has already been sent.
+Example:
+  Previous message:
+    <boltAction filePath="index.html"><!DOCTYPE html><html lang
+  Bad: Repeats the previous message. This creates an unreadable document.
+    <boltAction filePath="index.html"><!DOCTYPE html><html lang="en"><body>
+  Good: Continues from where the previous message left off:
+      ="en"><body>`;

--- a/app/lib/common/prompts/prompts.ts
+++ b/app/lib/common/prompts/prompts.ts
@@ -698,7 +698,12 @@ Here are some examples of correct usage of artifacts:
 </examples>
 `;
 
-export const CONTINUE_PROMPT = stripIndents`
-  Continue your prior response. IMPORTANT: Immediately begin from where you left off without any interruptions.
-  Do not repeat any content, including artifact and action tags.
-`;
+export const CONTINUE_PROMPT = `Continue your prior response.
+Important: continue your last message without any interruptions, even if you're in the middle of a thought. You are continuing a document that will be re-assembled later. Never repeat any text that has already been sent.
+Example:
+  Previous message:
+    <boltAction filePath="index.html"><!DOCTYPE html><html lang
+  Bad: Repeats the previous message. This creates an unreadable document.
+    <boltAction filePath="index.html"><!DOCTYPE html><html lang="en"><body>
+  Good: Continues from where the previous message left off:
+      ="en"><body>`;

--- a/app/lib/hooks/useMessageParser.ts
+++ b/app/lib/hooks/useMessageParser.ts
@@ -1,7 +1,8 @@
-import type { Message } from 'ai';
+import type { JSONValue, Message } from 'ai';
 import { useCallback, useState } from 'react';
 import { StreamingMessageParser } from '~/lib/runtime/message-parser';
 import { workbenchStore } from '~/lib/stores/workbench';
+import type { SegmentsGroupAnnotation } from '~/types/context';
 import { createScopedLogger } from '~/utils/logger';
 
 const logger = createScopedLogger('useMessageParser');
@@ -47,6 +48,14 @@ const extractTextContent = (message: Message) =>
     ? (message.content.find((item) => item.type === 'text')?.text as string) || ''
     : message.content;
 
+const segmentsGroupIdFromAnnotation = (annotation: JSONValue): string | null => {
+  if (annotation && typeof annotation === 'object' && 'type' in annotation && annotation.type === 'segmentsGroup') {
+    return (annotation as SegmentsGroupAnnotation).segmentsGroupId;
+  }
+
+  return null;
+};
+
 export function useMessageParser() {
   const [parsedMessages, setParsedMessages] = useState<{ [key: number]: string }>({});
 
@@ -58,13 +67,44 @@ export function useMessageParser() {
       messageParser.reset();
     }
 
+    const messageContents: Record<number, string> = {};
+    const segmentGroups: Record<string, { firstGroupIndex: number }> = {};
+
+    for (const [index, message] of messages.entries()) {
+      if (message.role === 'user') {
+        messageContents[index] = extractTextContent(message);
+      } else if (message.role === 'assistant') {
+        const segmentsGroupId = message.annotations?.reduce(
+          (groupId: string | null, a) => groupId ?? segmentsGroupIdFromAnnotation(a),
+          null,
+        );
+
+        if (!segmentsGroupId) {
+          messageContents[index] = extractTextContent(message);
+        } else {
+          const firstIndex = segmentGroups[segmentsGroupId]?.firstGroupIndex;
+
+          if (firstIndex === undefined) {
+            segmentGroups[segmentsGroupId] = { firstGroupIndex: index };
+            messageContents[index] = extractTextContent(message);
+          } else {
+            messageContents[firstIndex] += extractTextContent(message);
+          }
+        }
+      }
+    }
+
     for (const [index, message] of messages.entries()) {
       if (message.role === 'assistant' || message.role === 'user') {
-        const newParsedContent = messageParser.parse(message.id, extractTextContent(message));
-        setParsedMessages((prevParsed) => ({
-          ...prevParsed,
-          [index]: !reset ? (prevParsed[index] || '') + newParsedContent : newParsedContent,
-        }));
+        const content = messageContents[index];
+
+        if (content !== undefined) {
+          const newParsedContent = messageParser.parse(message.id, content);
+          setParsedMessages((prevParsed) => ({
+            ...prevParsed,
+            [index]: !reset ? (prevParsed[index] || '') + newParsedContent : newParsedContent,
+          }));
+        }
       }
     }
   }, []);

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -7,7 +7,7 @@ import SwitchableStream from '~/lib/.server/llm/switchable-stream';
 import type { IProviderSetting } from '~/types/model';
 import { createScopedLogger } from '~/utils/logger';
 import { getFilePaths, selectContext } from '~/lib/.server/llm/select-context';
-import type { ContextAnnotation, ProgressAnnotation } from '~/types/context';
+import type { ContextAnnotation, ProgressAnnotation, SegmentsGroupAnnotation } from '~/types/context';
 import { WORK_DIR } from '~/utils/constants';
 import { createSummary } from '~/lib/.server/llm/create-summary';
 import { extractPropertiesFromMessage } from '~/lib/.server/llm/utils';
@@ -59,6 +59,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
   );
 
   const stream = new SwitchableStream();
+  const segmentsGroupId = generateId();
 
   const cumulativeUsage = {
     completionTokens: 0,
@@ -237,6 +238,11 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               role: 'user',
               content: `[Model: ${model}]\n\n[Provider: ${provider}]\n\n${CONTINUE_PROMPT}`,
             });
+
+            dataStream.writeMessageAnnotation({
+              type: 'segmentsGroup',
+              segmentsGroupId,
+            } satisfies SegmentsGroupAnnotation);
 
             const result = await streamText({
               messages,

--- a/app/types/context.ts
+++ b/app/types/context.ts
@@ -16,3 +16,8 @@ export type ProgressAnnotation = {
   order: number;
   message: string;
 };
+
+export type SegmentsGroupAnnotation = {
+  type: 'segmentsGroup';
+  segmentsGroupId: string;
+};


### PR DESCRIPTION
This PR fixes a problem where a second trip through `streamText` would result in a broken UI.

When the `CONTINUE_PROMPT` is used in `api.chat.ts`, it results in a new `assistant` message. When that message goes through the parser, the parser doesn't have any of the previous state. This causes all of the tokens go straight into the chat.

With this change, the messages for a call to `api.chat.ts` get a shared `segmentsGroupId` that they can use to concatenate the messages into one big message. Then the parser doesn't lose the context.

Tested by setting `MAX_RESPONSE_TOKENS` to 200 in constants.ts and setting `maxTokens` to 100 in `stream-text.ts`.

I was also having trouble with the llm repeating previous content. I modified the continue prompt to include an example of what not to do that seems to help--tested with both `Claude 3.7 Sonnet` and `Claude 3.5 Haiku`.