### PR TITLE
feat: add Claude Opus and Sonnet 4 to Anthropic provider

### DIFF
--- a/app/lib/modules/llm/providers/anthropic.ts
+++ b/app/lib/modules/llm/providers/anthropic.ts
@@ -14,6 +14,18 @@ export default class AnthropicProvider extends BaseProvider {
 
   staticModels: ModelInfo[] = [
     {
+      name: 'claude-opus-4-20250514',
+      label: 'Claude Opus 4',
+      provider: 'Anthropic',
+      maxTokenAllowed: 128000
+    },
+    {
+      name: 'claude-sonnet-4-20250514',
+      label: 'Claude Sonnet 4',
+      provider: 'Anthropic',
+      maxTokenAllowed: 128000
+    },
+    {
       name: 'claude-3-7-sonnet-20250219',
       label: 'Claude 3.7 Sonnet',
       provider: 'Anthropic',


### PR DESCRIPTION
Adds drop-down support for two new Anthropic models:

* `claude-opus-4-20250514` – most capable model
* `claude-sonnet-4-20250514` – high-performance, efficient model

Both support 200k context windows and are added to `staticModels` with `maxTokenAllowed: 128000`.

🔗 [Model details](https://docs.anthropic.com/en/docs/about-claude/models/overview)