### PR TITLE
revert: "fix: increase Node.js memory limit in Docker build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV WRANGLER_SEND_METRICS=false \
 RUN mkdir -p /root/.config/.wrangler && \
     echo '{"enabled":false}' > /root/.config/.wrangler/metrics.json
 
-RUN node --max-old-space-size=4096 node_modules/.bin/pnpm run build
+RUN pnpm run build
 
 CMD [ "pnpm", "run", "dockerstart"]
 


### PR DESCRIPTION
Reverts stackblitz-labs/bolt.diy#1725

Due to causing github action docker build to fail