### PR TITLE
fix: openAI Context Length and Token Limit Issues

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -113,9 +113,11 @@ export async function streamText(props: {
     }
   }
 
-  const dynamicMaxTokens = modelDetails && modelDetails.maxTokenAllowed ? modelDetails.maxTokenAllowed : MAX_TOKENS;
+  const dynamicMaxTokens =
+    modelDetails.maxCompletionTokens ||
+    (modelDetails.maxTokenAllowed ? Math.min(modelDetails.maxTokenAllowed, MAX_TOKENS) : MAX_TOKENS);
   logger.info(
-    `Max tokens for model ${modelDetails.name} is ${dynamicMaxTokens} based on ${modelDetails.maxTokenAllowed} or ${MAX_TOKENS}`,
+    `Max tokens for model ${modelDetails.name} is ${dynamicMaxTokens} based on ${modelDetails.maxCompletionTokens || 'fallback logic'}`,
   );
 
   let systemPrompt =

--- a/app/lib/modules/llm/providers/github.ts
+++ b/app/lib/modules/llm/providers/github.ts
@@ -14,13 +14,55 @@ export default class GithubProvider extends BaseProvider {
 
   // find more in https://github.com/marketplace?type=models
   staticModels: ModelInfo[] = [
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000 },
-    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4-turbo', label: 'GPT-4 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
+    {
+      name: 'gpt-4o',
+      label: 'GPT-4o',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'o1',
+      label: 'o1-preview',
+      provider: 'Github',
+      maxTokenAllowed: 200000,
+      maxCompletionTokens: 32768,
+    },
+    {
+      name: 'o1-mini',
+      label: 'o1-mini',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 65536,
+    },
+    {
+      name: 'gpt-4o-mini',
+      label: 'GPT-4o Mini',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-4-turbo',
+      label: 'GPT-4 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-4',
+      label: 'GPT-4',
+      provider: 'Github',
+      maxTokenAllowed: 8192,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 16385,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/openai.ts
+++ b/app/lib/modules/llm/providers/openai.ts
@@ -13,11 +13,41 @@ export default class OpenAIProvider extends BaseProvider {
   };
 
   staticModels: ModelInfo[] = [
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'OpenAI', maxTokenAllowed: 8000 },
-    { name: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'OpenAI', maxTokenAllowed: 8000 },
-    { name: 'gpt-4-turbo', label: 'GPT-4 Turbo', provider: 'OpenAI', maxTokenAllowed: 8000 },
-    { name: 'gpt-4', label: 'GPT-4', provider: 'OpenAI', maxTokenAllowed: 8000 },
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'OpenAI', maxTokenAllowed: 8000 },
+    {
+      name: 'gpt-4o',
+      label: 'GPT-4o',
+      provider: 'OpenAI',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-4o-mini',
+      label: 'GPT-4o Mini',
+      provider: 'OpenAI',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-4-turbo',
+      label: 'GPT-4 Turbo',
+      provider: 'OpenAI',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-4',
+      label: 'GPT-4',
+      provider: 'OpenAI',
+      maxTokenAllowed: 8192,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'OpenAI',
+      maxTokenAllowed: 16385,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   async getDynamicModels(

--- a/app/lib/modules/llm/types.ts
+++ b/app/lib/modules/llm/types.ts
@@ -6,6 +6,7 @@ export interface ModelInfo {
   label: string;
   provider: string;
   maxTokenAllowed: number;
+  maxCompletionTokens?: number;
 }
 
 export interface ProviderInfo {

--- a/app/routes/api.llmcall.ts
+++ b/app/routes/api.llmcall.ts
@@ -101,7 +101,9 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
         throw new Error('Model not found');
       }
 
-      const dynamicMaxTokens = modelDetails && modelDetails.maxTokenAllowed ? modelDetails.maxTokenAllowed : MAX_TOKENS;
+      const dynamicMaxTokens =
+        modelDetails.maxCompletionTokens ||
+        (modelDetails.maxTokenAllowed ? Math.min(modelDetails.maxTokenAllowed, MAX_TOKENS) : MAX_TOKENS);
 
       const providerInfo = PROVIDER_LIST.find((p) => p.name === provider.name);
 


### PR DESCRIPTION
## 🔧 Fix: OpenAI Context Length and Token Limit Issues

### Problem
- **GPT-3.5-turbo** and other OpenAI models were throwing `max_tokens is too large` errors
- Application was incorrectly using full context window size (16,385 tokens) as completion token limit
- OpenAI models have separate limits for total context vs completion tokens
- GPT-3.5-turbo: 16,385 context window but only 4,096 max completion tokens

### Root Cause
The codebase was confusing **context window size** (total input + output tokens) with **completion token limits** (maximum output tokens only), causing the API to reject requests when `maxTokens` was set to the full context window size.

### Changes Made

#### 🆕 New Features
- Added `maxCompletionTokens` field to `ModelInfo` interface for proper token limit handling
- Enhanced token allocation logic to distinguish between context window and completion limits

#### 🔄 Updated Model Configurations

**OpenAI Provider (`app/lib/modules/llm/providers/openai.ts`)**
- ✅ GPT-3.5-turbo: Context 16,385 → Completion 4,096 tokens
- ✅ GPT-4: Context 8,192 → Completion 4,096 tokens
- ✅ GPT-4-turbo: Context 128,000 → Completion 4,096 tokens
- ✅ GPT-4o/GPT-4o-mini: Context 128,000 → Completion 4,096 tokens

**GitHub Provider (`app/lib/modules/llm/providers/github.ts`)**
- ✅ Same OpenAI model fixes
- ✅ o1-preview: Context 200,000 → Completion 32,768 tokens
- ✅ o1-mini: Context 128,000 → Completion 65,536 tokens

#### 🛠️ Logic Improvements
- Updated `api.llmcall.ts` to use `maxCompletionTokens` when available
- Updated `stream-text.ts` with same token allocation logic
- Added fallback logic: `Math.min(contextWindow, MAX_TOKENS)` when completion limit not specified
- Improved logging to show which token limit is being used

### Files Modified
- `app/lib/modules/llm/types.ts` - Added `maxCompletionTokens` field
- `app/lib/modules/llm/providers/openai.ts` - Updated model configurations
- `app/lib/modules/llm/providers/github.ts` - Updated model configurations
- `app/routes/api.llmcall.ts` - Fixed token allocation logic
- `app/lib/.server/llm/stream-text.ts` - Fixed token allocation logic

### Impact
- ✅ **Resolves** "max_tokens is too large" errors for GPT-3.5-turbo and other OpenAI models
- ✅ **Enables** full utilization of model context windows for input
- ✅ **Maintains** proper completion token limits per model specifications
- ✅ **Preserves** backward compatibility for models without specified completion limits
- ✅ **Improves** token usage efficiency and error handling

### Testing
- Verified GPT-3.5-turbo no longer throws completion token errors
- Confirmed context windows are properly utilized
- Tested fallback logic for models without completion token specifications