### PR TITLE
feat: chutes provider

### DIFF
--- a/app/lib/modules/llm/providers/chute.ts
+++ b/app/lib/modules/llm/providers/chute.ts
@@ -14,10 +14,65 @@ export default class ChuteProvider extends BaseProvider {
   staticModels: ModelInfo[] = [
     {
       name: 'deepseek-ai/DeepSeek-V3-0324',
-      label: 'Deepseek V3 (Chute)',
+      label: 'Deepseek V3 (Free)',
       provider: 'Chute',
       maxTokenAllowed: 4096,
     },
+    {
+      name: 'deepseek-ai/DeepSeek-R1-0528',
+      label: 'Deepseek R1 (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'tngtech/DeepSeek-R1T-Chimera',
+      label: 'DeepSeek-R1T-Chimera (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'microsoft/MAI-DS-R1-FP8',
+      label: 'MAI-DS-R1-FP8 (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'Qwen/Qwen3-235B-A22B',
+      label: 'Qwen3-235B-A22B (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'chutesai/Mistral-Small-3.1-24B-Instruct-2503',
+      label: 'Mistral-Small-3.1-24B-Instruct-2503 (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'deepseek-ai/DeepSeek-R1-0528-Qwen3-8B',
+      label: 'DeepSeek-R1-0528-Qwen3-8B (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'agentica-org/DeepCoder-14B-Preview',
+      label: 'DeepCoder-14B-Preview (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'nvidia/Llama-3_1-Nemotron-Ultra-253B-v1',
+      label: 'Llama-3.1-Nemotron-Ultra-253B-v1 (Free)',
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    {
+      name: 'ByteDance-Seed/Seed-Coder-8B-Reasoning-bf16', // New model added
+      label: 'Seed-Coder-8B-Reasoning-bf16 (Free)', // Label for the new model
+      provider: 'Chute',
+      maxTokenAllowed: 1024,
+    },
+    // Add other Chute models here following the same structure
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/chute.ts
+++ b/app/lib/modules/llm/providers/chute.ts
@@ -1,0 +1,49 @@
+import { BaseProvider, getOpenAILikeModel } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+
+export default class ChuteProvider extends BaseProvider {
+  name = 'Chute';
+
+  config = {
+    apiTokenKey: 'CHUTES_API_TOKEN',
+    baseUrl: 'https://llm.chutes.ai/v1',
+  };
+
+  staticModels: ModelInfo[] = [
+    {
+      name: 'deepseek-ai/DeepSeek-V3-0324',
+      label: 'Deepseek V3 (Chute)',
+      provider: 'Chute',
+      maxTokenAllowed: 4096,
+    },
+  ];
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    const { baseUrl, apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: '', // Chute has a fixed base URL
+      defaultApiTokenKey: 'CHUTES_API_TOKEN',
+    });
+
+    if (!apiKey) {
+      throw new Error(`Missing API key for ${this.name} provider`);
+    }
+
+    if (!baseUrl) {
+      throw new Error(`Missing base URL for ${this.name} provider`);
+    }
+
+    return getOpenAILikeModel(baseUrl, apiKey, model);
+  }
+}

--- a/app/lib/modules/llm/providers/chutes.ts
+++ b/app/lib/modules/llm/providers/chutes.ts
@@ -3,8 +3,8 @@ import type { ModelInfo } from '~/lib/modules/llm/types';
 import type { IProviderSetting } from '~/types/model';
 import type { LanguageModelV1 } from 'ai';
 
-export default class ChuteProvider extends BaseProvider {
-  name = 'Chute';
+export default class ChutesProvider extends BaseProvider {
+  name = 'Chutes';
 
   config = {
     apiTokenKey: 'CHUTES_API_TOKEN',
@@ -14,65 +14,65 @@ export default class ChuteProvider extends BaseProvider {
   staticModels: ModelInfo[] = [
     {
       name: 'deepseek-ai/DeepSeek-V3-0324',
-      label: 'Deepseek V3 (Free)',
-      provider: 'Chute',
+      label: 'Deepseek V3-0324 (Free)',
+      provider: 'Chutes',
       maxTokenAllowed: 4096,
     },
     {
       name: 'deepseek-ai/DeepSeek-R1-0528',
-      label: 'Deepseek R1 (Free)',
-      provider: 'Chute',
+      label: 'Deepseek R1-0528 (Free)',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'tngtech/DeepSeek-R1T-Chimera',
       label: 'DeepSeek-R1T-Chimera (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'microsoft/MAI-DS-R1-FP8',
       label: 'MAI-DS-R1-FP8 (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'Qwen/Qwen3-235B-A22B',
       label: 'Qwen3-235B-A22B (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'chutesai/Mistral-Small-3.1-24B-Instruct-2503',
       label: 'Mistral-Small-3.1-24B-Instruct-2503 (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'deepseek-ai/DeepSeek-R1-0528-Qwen3-8B',
       label: 'DeepSeek-R1-0528-Qwen3-8B (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'agentica-org/DeepCoder-14B-Preview',
       label: 'DeepCoder-14B-Preview (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
       name: 'nvidia/Llama-3_1-Nemotron-Ultra-253B-v1',
       label: 'Llama-3.1-Nemotron-Ultra-253B-v1 (Free)',
-      provider: 'Chute',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
     {
-      name: 'ByteDance-Seed/Seed-Coder-8B-Reasoning-bf16', // New model added
-      label: 'Seed-Coder-8B-Reasoning-bf16 (Free)', // Label for the new model
-      provider: 'Chute',
+      name: 'ByteDance-Seed/Seed-Coder-8B-Reasoning-bf16',
+      label: 'Seed-Coder-8B-Reasoning-bf16 (Free)',
+      provider: 'Chutes',
       maxTokenAllowed: 1024,
     },
-    // Add other Chute models here following the same structure
+    // Add other Chutes models here following the same structure
   ];
 
   getModelInstance(options: {
@@ -87,7 +87,7 @@ export default class ChuteProvider extends BaseProvider {
       apiKeys,
       providerSettings: providerSettings?.[this.name],
       serverEnv: serverEnv as any,
-      defaultBaseUrlKey: '', // Chute has a fixed base URL
+      defaultBaseUrlKey: '', // Chutes has a fixed base URL
       defaultApiTokenKey: 'CHUTES_API_TOKEN',
     });
 

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -16,10 +16,12 @@ import XAIProvider from './providers/xai';
 import HyperbolicProvider from './providers/hyperbolic';
 import AmazonBedrockProvider from './providers/amazon-bedrock';
 import GithubProvider from './providers/github';
+import ChuteProvider from './providers/chute';
 
 export {
   AnthropicProvider,
   CohereProvider,
+  ChuteProvider,
   DeepseekProvider,
   GoogleProvider,
   GroqProvider,

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -16,12 +16,12 @@ import XAIProvider from './providers/xai';
 import HyperbolicProvider from './providers/hyperbolic';
 import AmazonBedrockProvider from './providers/amazon-bedrock';
 import GithubProvider from './providers/github';
-import ChuteProvider from './providers/chute';
+import ChutesProvider from './providers/chutes';
 
 export {
   AnthropicProvider,
   CohereProvider,
-  ChuteProvider,
+  ChutesProvider,
   DeepseekProvider,
   GoogleProvider,
   GroqProvider,


### PR DESCRIPTION
This is a simple edit that adds Chutes (https://chutes.ai) as a provider and includes their most popular models. It adds a new provider file app/lib/modules/llm/providers/chutes.ts and makes an addition into the app/lib/modules/llm/registry.ts file.