### PR TITLE
feat: add support for OPENAI_LIKE_API_MODELS

### DIFF
--- a/app/lib/modules/llm/providers/openai-like.ts
+++ b/app/lib/modules/llm/providers/openai-like.ts
@@ -10,9 +10,46 @@ export default class OpenAILikeProvider extends BaseProvider {
   config = {
     baseUrlKey: 'OPENAI_LIKE_API_BASE_URL',
     apiTokenKey: 'OPENAI_LIKE_API_KEY',
+    modelKey: 'OPENAI_LIKE_API_MODELS',
   };
 
   staticModels: ModelInfo[] = [];
+
+  getEnvDefinedModels(serverEnv: Record<string, string> = {}): ModelInfo[] {
+    const models = serverEnv[this.config.modelKey] || process.env[this.config.modelKey];
+    console.debug(`${this.name}: ${this.config.modelKey}=${models}`);
+
+    const mklabel = (model: string) => {
+      let parts = model.split('/').reverse() || [];
+      parts = parts.filter((p) => p && !p.includes('accounts') && !p.includes('models'));
+
+      let label = parts.join('-');
+
+      if (parts.length >= 2) {
+        label = `${parts.shift()} (${parts.join(', ')})`;
+      }
+
+      return label.toLowerCase().replace(/\b\w/g, (match) => match.toUpperCase());
+    };
+
+    const ret =
+      models?.split(';').map((model: string) => {
+        const parts = model.split(':');
+        const name = (parts.length && parts.shift()?.trim()) || 'parse-error';
+        const ret = {
+          name,
+          label: mklabel(name),
+          provider: this.name,
+          maxTokenAllowed: parseInt(parts.shift() || '0'),
+        };
+
+        return ret;
+      }) || [];
+
+    console.debug(`${this.name}: Parsed Models: `, ...ret);
+
+    return ret;
+  }
 
   async getDynamicModels(
     apiKeys?: Record<string, string>,
@@ -34,17 +71,29 @@ export default class OpenAILikeProvider extends BaseProvider {
     const response = await fetch(`${baseUrl}/models`, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
+        ContentType: 'application/json',
       },
     });
 
-    const res = (await response.json()) as any;
+    let ret = [];
 
-    return res.data.map((model: any) => ({
-      name: model.id,
-      label: model.id,
-      provider: this.name,
-      maxTokenAllowed: 8000,
-    }));
+    try {
+      const json = (await response.json()) as any;
+      ret = json.data.map((model: any) => ({
+        name: model.id,
+        label: model.id,
+        provider: this.name,
+        maxTokenAllowed: 8000,
+      }));
+    } catch {
+      if (response.headers.has('x-error-message')) {
+        const xerr = response.headers.get('x-error-message');
+        console.debug(`${this.name}: ${xerr}`);
+        ret = this.getEnvDefinedModels(serverEnv);
+      }
+    }
+
+    return ret;
   }
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/openai-like.ts
+++ b/app/lib/modules/llm/providers/openai-like.ts
@@ -16,7 +16,11 @@ export default class OpenAILikeProvider extends BaseProvider {
   staticModels: ModelInfo[] = [];
 
   getEnvDefinedModels(serverEnv: Record<string, string> = {}): ModelInfo[] {
-    const models = serverEnv[this.config.modelKey] || process.env[this.config.modelKey];
+    const models =
+      serverEnv[this.config.modelKey] ||
+      process.env[this.config.modelKey] ||
+      import.meta.env[this.config.modelKey] ||
+      '';
     console.debug(`${this.name}: ${this.config.modelKey}=${models}`);
 
     const mklabel = (model: string) => {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "electron:build:main": "vite build --config ./electron/main/vite.config.ts",
     "electron:build:preload": "vite build --config ./electron/preload/vite.config.ts",
     "electron:build:renderer": "remix vite:build --config vite-electron.config.js",
-    "electron:build:unpack": "rm -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --dir",
-    "electron:build:mac": "rm -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --mac",
-    "electron:build:win": "rm -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --win",
-    "electron:build:linux": "rm -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --linux",
-    "electron:build:dist": "rm -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --mwl"
+    "electron:build:unpack": "rimraf -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --dir",
+    "electron:build:mac": "rimraf -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --mac",
+    "electron:build:win": "rimraf -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --win",
+    "electron:build:linux": "rimraf -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --linux",
+    "electron:build:dist": "rimraf -rf dist && pnpm electron:build:renderer && pnpm electron:build:deps && electron-builder --mwl"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/vite-electron.config.ts
+++ b/vite-electron.config.ts
@@ -59,7 +59,7 @@ export default defineConfig((config) => {
     ],
     envPrefix: [
       'VITE_',
-      'OPENAI_LIKE_API_BASE_URL',
+      'OPENAI_LIKE_API_',
       'OLLAMA_API_BASE_URL',
       'LMSTUDIO_API_BASE_URL',
       'TOGETHER_API_BASE_URL',


### PR DESCRIPTION
Enable env definition OPENAI_LIKE_API_MODELS=path/to/model1:limit;path/to/model2:limit;path/to/model3:limit

This helps construct the missing model list when the endpoint does not support /models/ request. E.g.

```
OPENAI_LIKE_API_BASE_URL": "https://router.huggingface.co/fireworks-ai/inference/v1
OPENAI_LIKE_API_MODELS=accounts/fireworks/models/deepseek-v3-0324:64000;accounts/fireworks/models/deepseek-v3:64000
> response.headers.get('x-error-message')
'Not allowed to GET inference/v1/models for provider fireworks-ai'
```

This results in empty list of model. Makes OpenAI Like provider unusable for special endpoints. This commit checks for such error condition and then parses OPENAI_LIKE_API_MODELS from environment to produce a customized list of models.

```
OpenAILike: Not allowed to GET inference/v1/models for provider fireworks-ai
OpenAILike: OPENAI_LIKE_API_MODELS=accounts/fireworks/models/deepseek-v3-0324:64000;accounts/fireworks/models/deepseek-v3:64000
OpenAILike: Parsed Models:
  {name: 'accounts/fireworks/models/deepseek-v3-0324', label: 'Deepseek-V3-0324 (Fireworks)', provider: 'OpenAILike', maxTokenAllowed: 64000},
  {name: 'accounts/fireworks/models/deepseek-v3', label: 'Deepseek-V3 (Fireworks)', provider: 'OpenAILike', maxTokenAllowed: 64000}
```

When this fixed ModelInfo[] is returned from getDynamicModels, the model selection UI gets populated with the expected list of models. Without this fix, it remains blank.