### PR TITLE
fix: token limits & Temperature Parameter Errors for Reasoning Models

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -4,6 +4,44 @@
  */
 export const MAX_TOKENS = 32000;
 
+/*
+ * Provider-specific default completion token limits
+ * Used as fallbacks when model doesn't specify maxCompletionTokens
+ */
+export const PROVIDER_COMPLETION_LIMITS: Record<string, number> = {
+  OpenAI: 16384,
+  Github: 16384, // GitHub Models use OpenAI-compatible limits
+  Anthropic: 128000,
+  Google: 32768,
+  Cohere: 4000,
+  DeepSeek: 8192,
+  Groq: 8192,
+  HuggingFace: 4096,
+  Mistral: 8192,
+  Ollama: 8192,
+  OpenRouter: 8192,
+  Perplexity: 8192,
+  Together: 8192,
+  xAI: 8192,
+  LMStudio: 8192,
+  OpenAILike: 8192,
+  AmazonBedrock: 8192,
+  Hyperbolic: 8192,
+};
+
+/*
+ * Reasoning models that require maxCompletionTokens instead of maxTokens
+ * These models use internal reasoning tokens and have different API parameter requirements
+ */
+export function isReasoningModel(modelName: string): boolean {
+  const result = /^(o1|o3|gpt-5)/i.test(modelName);
+
+  // DEBUG: Test regex matching
+  console.log(`REGEX TEST: "${modelName}" matches reasoning pattern: ${result}`);
+
+  return result;
+}
+
 // limits the number of model responses that can be returned in a single request
 export const MAX_RESPONSE_SEGMENTS = 2;
 

--- a/app/lib/modules/llm/providers/anthropic.ts
+++ b/app/lib/modules/llm/providers/anthropic.ts
@@ -22,6 +22,7 @@ export default class AnthropicProvider extends BaseProvider {
       label: 'Claude 3.5 Sonnet',
       provider: 'Anthropic',
       maxTokenAllowed: 200000,
+      maxCompletionTokens: 128000,
     },
 
     // Claude 3 Haiku: 200k context, fastest and most cost-effective
@@ -30,6 +31,7 @@ export default class AnthropicProvider extends BaseProvider {
       label: 'Claude 3 Haiku',
       provider: 'Anthropic',
       maxTokenAllowed: 200000,
+      maxCompletionTokens: 128000,
     },
   ];
 
@@ -84,6 +86,7 @@ export default class AnthropicProvider extends BaseProvider {
         label: `${m.display_name} (${Math.floor(contextWindow / 1000)}k context)`,
         provider: this.name,
         maxTokenAllowed: contextWindow,
+        maxCompletionTokens: 128000, // Claude models support up to 128k completion tokens
       };
     });
   }

--- a/app/lib/modules/llm/providers/github.ts
+++ b/app/lib/modules/llm/providers/github.ts
@@ -14,13 +14,31 @@ export default class GithubProvider extends BaseProvider {
 
   // find more in https://github.com/marketplace?type=models
   staticModels: ModelInfo[] = [
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000 },
-    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4-turbo', label: 'GPT-4 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 128000, maxCompletionTokens: 16384 },
+    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000, maxCompletionTokens: 16384 },
+    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 65536, maxCompletionTokens: 8192 },
+    {
+      name: 'gpt-4o-mini',
+      label: 'GPT-4o Mini',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 16384,
+    },
+    {
+      name: 'gpt-4-turbo',
+      label: 'GPT-4 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 8192,
+    },
+    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8192, maxCompletionTokens: 8192 },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 16385,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/google.ts
+++ b/app/lib/modules/llm/providers/google.ts
@@ -17,10 +17,22 @@ export default class GoogleProvider extends BaseProvider {
      * Essential fallback models - only the most reliable/stable ones
      * Gemini 1.5 Pro: 2M context, excellent for complex reasoning and large codebases
      */
-    { name: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro', provider: 'Google', maxTokenAllowed: 2000000 },
+    {
+      name: 'gemini-1.5-pro',
+      label: 'Gemini 1.5 Pro',
+      provider: 'Google',
+      maxTokenAllowed: 2000000,
+      maxCompletionTokens: 32768,
+    },
 
     // Gemini 1.5 Flash: 1M context, fast and cost-effective
-    { name: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash', provider: 'Google', maxTokenAllowed: 1000000 },
+    {
+      name: 'gemini-1.5-flash',
+      label: 'Gemini 1.5 Flash',
+      provider: 'Google',
+      maxTokenAllowed: 1000000,
+      maxCompletionTokens: 32768,
+    },
   ];
 
   async getDynamicModels(
@@ -89,11 +101,19 @@ export default class GoogleProvider extends BaseProvider {
       const maxAllowed = 2000000; // 2M tokens max
       const finalContext = Math.min(contextWindow, maxAllowed);
 
+      // Get completion token limit from Google API
+      let completionTokens = 32768; // default fallback
+
+      if (m.outputTokenLimit && m.outputTokenLimit > 0) {
+        completionTokens = Math.min(m.outputTokenLimit, 128000); // Cap at reasonable limit
+      }
+
       return {
         name: modelName,
         label: `${m.displayName} (${finalContext >= 1000000 ? Math.floor(finalContext / 1000000) + 'M' : Math.floor(finalContext / 1000) + 'k'} context)`,
         provider: this.name,
         maxTokenAllowed: finalContext,
+        maxCompletionTokens: completionTokens,
       };
     });
   }

--- a/app/lib/modules/llm/providers/openai.ts
+++ b/app/lib/modules/llm/providers/openai.ts
@@ -17,10 +17,16 @@ export default class OpenAIProvider extends BaseProvider {
      * Essential fallback models - only the most stable/reliable ones
      * GPT-4o: 128k context, high performance, recommended for most tasks
      */
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'OpenAI', maxTokenAllowed: 128000 },
+    { name: 'gpt-4o', label: 'GPT-4o', provider: 'OpenAI', maxTokenAllowed: 128000, maxCompletionTokens: 16384 },
 
     // GPT-3.5-turbo: 16k context, fast and cost-effective
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'OpenAI', maxTokenAllowed: 16000 },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'OpenAI',
+      maxTokenAllowed: 16000,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   async getDynamicModels(

--- a/app/lib/modules/llm/types.ts
+++ b/app/lib/modules/llm/types.ts
@@ -5,7 +5,12 @@ export interface ModelInfo {
   name: string;
   label: string;
   provider: string;
+
+  /** Maximum context window size (input tokens) - how many tokens the model can process */
   maxTokenAllowed: number;
+
+  /** Maximum completion/output tokens - how many tokens the model can generate. If not specified, falls back to provider defaults */
+  maxCompletionTokens?: number;
 }
 
 export interface ProviderInfo {


### PR DESCRIPTION
# Fix Token Limits & Temperature Parameter Errors for Reasoning Models

## 🐛 Problem
Reasoning models (**GPT-5, o1, o3 series**) were failing due to two critical parameter compatibility issues:  
1. **Token Limit Error** — `max_tokens` is too large: `100000`. This model supports at most **16384** completion tokens.  
2. **Temperature Parameter Error** — Unsupported value: `temperature` does not support `0` with reasoning models. Only the default (`1`) value is supported.  

## 🔍 Root Cause
OpenAI's reasoning models have different API parameter requirements than traditional models:  
- **Token Parameters**: Require `maxCompletionTokens` instead of `maxTokens`  
- **Temperature**: Only support `temperature: 1` (no custom values)  
- **Unsupported Parameters**: Many traditional parameters (`topP`, `presencePenalty`, etc.) are not supported  

## ✅ Solution
**1. Model Detection System**  
```ts
export function isReasoningModel(modelName: string): boolean {
  return /^(o1|o3|gpt-5)/i.test(modelName);
}
```  
**2. Provider-Specific Token Limits**  
```ts
export const PROVIDER_COMPLETION_LIMITS: Record<string, number> = {
  OpenAI: 16384,
  Anthropic: 128000,
  Google: 32768,
  // ... other providers
};
```  
**3. Parameter Compatibility Logic**  
Token Parameters:  
```ts
const tokenParams = isReasoning
  ? { maxCompletionTokens: safeMaxTokens }
  : { maxTokens: safeMaxTokens };
```  
Temperature Parameters:  
```ts
const finalParams = isReasoning
  ? { ...baseParams, temperature: 1 }   // Required for reasoning models
  : { ...baseParams, temperature: 0 };  // Deterministic for traditional models
```  
Parameter Filtering (Streaming):  
```ts
const filteredOptions = isReasoning && options
  ? Object.fromEntries(
      Object.entries(options).filter(
        ([key]) => ![
          'temperature', 'topP', 'presencePenalty',
          'frequencyPenalty', 'logprobs', 'topLogprobs', 'logitBias'
        ].includes(key)
      )
    )
  : options || {};
```

## 📁 Files Changed
- `app/lib/.server/llm/constants.ts` → Added reasoning model detection & provider limits  
- `app/lib/.server/llm/stream-text.ts` → Fixed streaming parameter compatibility  
- `app/routes/api.llmcall.ts` → Fixed direct API call parameters  
- `app/lib/modules/llm/types.ts` → Added `maxCompletionTokens` field  
- `app/lib/modules/llm/providers/*` → Updated model definitions with completion token limits  

## 🧪 Testing
Verified with multiple reasoning models:  
- ✅ `gpt-5` → Working with correct parameters  
- ✅ `gpt-5-chat-latest` → Successful completion  
- ✅ `o1-preview` → Parameter compatibility confirmed  
- ✅ Traditional models (`GPT-4`, `Claude`) → Unchanged behavior maintained  

## 🎯 Impact
- **Before**: Reasoning models were completely unusable due to parameter errors  
- **After**: Full compatibility with OpenAI reasoning models, while preserving traditional model functionality  
- **Backward Compatible**: No breaking changes for existing traditional model usage  

## 🔧 Debug Logging
Added debug logging for troubleshooting:  
```ts
logger.info(`DEBUG: Model "${modelName}" detected as reasoning model: ${isReasoning}`);
logger.info(`DEBUG: Final params:`, { hasTemperature, hasMaxTokens, hasMaxCompletionTokens });
```  

✅ This fix ensures **seamless integration** with OpenAI's latest reasoning models while maintaining **backward compatibility** with all existing model providers.