### PR TITLE
fix: maxCompletionTokens Implementation for All Providers

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -4,6 +4,44 @@
  */
 export const MAX_TOKENS = 32000;
 
+/*
+ * Provider-specific default completion token limits
+ * Used as fallbacks when model doesn't specify maxCompletionTokens
+ */
+export const PROVIDER_COMPLETION_LIMITS: Record<string, number> = {
+  OpenAI: 16384,
+  Github: 16384, // GitHub Models use OpenAI-compatible limits
+  Anthropic: 128000,
+  Google: 32768,
+  Cohere: 4000,
+  DeepSeek: 8192,
+  Groq: 8192,
+  HuggingFace: 4096,
+  Mistral: 8192,
+  Ollama: 8192,
+  OpenRouter: 8192,
+  Perplexity: 8192,
+  Together: 8192,
+  xAI: 8192,
+  LMStudio: 8192,
+  OpenAILike: 8192,
+  AmazonBedrock: 8192,
+  Hyperbolic: 8192,
+};
+
+/*
+ * Reasoning models that require maxCompletionTokens instead of maxTokens
+ * These models use internal reasoning tokens and have different API parameter requirements
+ */
+export function isReasoningModel(modelName: string): boolean {
+  const result = /^(o1|o3|gpt-5)/i.test(modelName);
+
+  // DEBUG: Test regex matching
+  console.log(`REGEX TEST: "${modelName}" matches reasoning pattern: ${result}`);
+
+  return result;
+}
+
 // limits the number of model responses that can be returned in a single request
 export const MAX_RESPONSE_SEGMENTS = 2;
 

--- a/app/lib/modules/llm/providers/anthropic.ts
+++ b/app/lib/modules/llm/providers/anthropic.ts
@@ -22,6 +22,7 @@ export default class AnthropicProvider extends BaseProvider {
       label: 'Claude 3.5 Sonnet',
       provider: 'Anthropic',
       maxTokenAllowed: 200000,
+      maxCompletionTokens: 128000,
     },
 
     // Claude 3 Haiku: 200k context, fastest and most cost-effective
@@ -30,6 +31,7 @@ export default class AnthropicProvider extends BaseProvider {
       label: 'Claude 3 Haiku',
       provider: 'Anthropic',
       maxTokenAllowed: 200000,
+      maxCompletionTokens: 128000,
     },
   ];
 
@@ -84,6 +86,7 @@ export default class AnthropicProvider extends BaseProvider {
         label: `${m.display_name} (${Math.floor(contextWindow / 1000)}k context)`,
         provider: this.name,
         maxTokenAllowed: contextWindow,
+        maxCompletionTokens: 128000, // Claude models support up to 128k completion tokens
       };
     });
   }

--- a/app/lib/modules/llm/providers/cohere.ts
+++ b/app/lib/modules/llm/providers/cohere.ts
@@ -13,16 +13,64 @@ export default class CohereProvider extends BaseProvider {
   };
 
   staticModels: ModelInfo[] = [
-    { name: 'command-r-plus-08-2024', label: 'Command R plus Latest', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-r-08-2024', label: 'Command R Latest', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-r-plus', label: 'Command R plus', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-r', label: 'Command R', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command', label: 'Command', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-nightly', label: 'Command Nightly', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-light', label: 'Command Light', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'command-light-nightly', label: 'Command Light Nightly', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'c4ai-aya-expanse-8b', label: 'c4AI Aya Expanse 8b', provider: 'Cohere', maxTokenAllowed: 4096 },
-    { name: 'c4ai-aya-expanse-32b', label: 'c4AI Aya Expanse 32b', provider: 'Cohere', maxTokenAllowed: 4096 },
+    {
+      name: 'command-r-plus-08-2024',
+      label: 'Command R plus Latest',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'command-r-08-2024',
+      label: 'Command R Latest',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'command-r-plus',
+      label: 'Command R plus',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    { name: 'command-r', label: 'Command R', provider: 'Cohere', maxTokenAllowed: 4096, maxCompletionTokens: 4000 },
+    { name: 'command', label: 'Command', provider: 'Cohere', maxTokenAllowed: 4096, maxCompletionTokens: 4000 },
+    {
+      name: 'command-nightly',
+      label: 'Command Nightly',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'command-light',
+      label: 'Command Light',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'command-light-nightly',
+      label: 'Command Light Nightly',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'c4ai-aya-expanse-8b',
+      label: 'c4AI Aya Expanse 8b',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
+    {
+      name: 'c4ai-aya-expanse-32b',
+      label: 'c4AI Aya Expanse 32b',
+      provider: 'Cohere',
+      maxTokenAllowed: 4096,
+      maxCompletionTokens: 4000,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/deepseek.ts
+++ b/app/lib/modules/llm/providers/deepseek.ts
@@ -13,9 +13,27 @@ export default class DeepseekProvider extends BaseProvider {
   };
 
   staticModels: ModelInfo[] = [
-    { name: 'deepseek-coder', label: 'Deepseek-Coder', provider: 'Deepseek', maxTokenAllowed: 8000 },
-    { name: 'deepseek-chat', label: 'Deepseek-Chat', provider: 'Deepseek', maxTokenAllowed: 8000 },
-    { name: 'deepseek-reasoner', label: 'Deepseek-Reasoner', provider: 'Deepseek', maxTokenAllowed: 8000 },
+    {
+      name: 'deepseek-coder',
+      label: 'Deepseek-Coder',
+      provider: 'Deepseek',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'deepseek-chat',
+      label: 'Deepseek-Chat',
+      provider: 'Deepseek',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'deepseek-reasoner',
+      label: 'Deepseek-Reasoner',
+      provider: 'Deepseek',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/github.ts
+++ b/app/lib/modules/llm/providers/github.ts
@@ -14,13 +14,31 @@ export default class GithubProvider extends BaseProvider {
 
   // find more in https://github.com/marketplace?type=models
   staticModels: ModelInfo[] = [
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000 },
-    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4-turbo', label: 'GPT-4 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8000 },
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'Github', maxTokenAllowed: 8000 },
+    { name: 'gpt-4o', label: 'GPT-4o', provider: 'Github', maxTokenAllowed: 128000, maxCompletionTokens: 16384 },
+    { name: 'o1', label: 'o1-preview', provider: 'Github', maxTokenAllowed: 100000, maxCompletionTokens: 16384 },
+    { name: 'o1-mini', label: 'o1-mini', provider: 'Github', maxTokenAllowed: 65536, maxCompletionTokens: 8192 },
+    {
+      name: 'gpt-4o-mini',
+      label: 'GPT-4o Mini',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 16384,
+    },
+    {
+      name: 'gpt-4-turbo',
+      label: 'GPT-4 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 8192,
+    },
+    { name: 'gpt-4', label: 'GPT-4', provider: 'Github', maxTokenAllowed: 8192, maxCompletionTokens: 8192 },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'Github',
+      maxTokenAllowed: 16385,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/google.ts
+++ b/app/lib/modules/llm/providers/google.ts
@@ -17,10 +17,22 @@ export default class GoogleProvider extends BaseProvider {
      * Essential fallback models - only the most reliable/stable ones
      * Gemini 1.5 Pro: 2M context, excellent for complex reasoning and large codebases
      */
-    { name: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro', provider: 'Google', maxTokenAllowed: 2000000 },
+    {
+      name: 'gemini-1.5-pro',
+      label: 'Gemini 1.5 Pro',
+      provider: 'Google',
+      maxTokenAllowed: 2000000,
+      maxCompletionTokens: 32768,
+    },
 
     // Gemini 1.5 Flash: 1M context, fast and cost-effective
-    { name: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash', provider: 'Google', maxTokenAllowed: 1000000 },
+    {
+      name: 'gemini-1.5-flash',
+      label: 'Gemini 1.5 Flash',
+      provider: 'Google',
+      maxTokenAllowed: 1000000,
+      maxCompletionTokens: 32768,
+    },
   ];
 
   async getDynamicModels(
@@ -89,11 +101,19 @@ export default class GoogleProvider extends BaseProvider {
       const maxAllowed = 2000000; // 2M tokens max
       const finalContext = Math.min(contextWindow, maxAllowed);
 
+      // Get completion token limit from Google API
+      let completionTokens = 32768; // default fallback
+
+      if (m.outputTokenLimit && m.outputTokenLimit > 0) {
+        completionTokens = Math.min(m.outputTokenLimit, 128000); // Cap at reasonable limit
+      }
+
       return {
         name: modelName,
         label: `${m.displayName} (${finalContext >= 1000000 ? Math.floor(finalContext / 1000000) + 'M' : Math.floor(finalContext / 1000) + 'k'} context)`,
         provider: this.name,
         maxTokenAllowed: finalContext,
+        maxCompletionTokens: completionTokens,
       };
     });
   }

--- a/app/lib/modules/llm/providers/groq.ts
+++ b/app/lib/modules/llm/providers/groq.ts
@@ -17,7 +17,13 @@ export default class GroqProvider extends BaseProvider {
      * Essential fallback models - only the most stable/reliable ones
      * Llama 3.1 8B: 128k context, fast and efficient
      */
-    { name: 'llama-3.1-8b-instant', label: 'Llama 3.1 8B', provider: 'Groq', maxTokenAllowed: 128000 },
+    {
+      name: 'llama-3.1-8b-instant',
+      label: 'Llama 3.1 8B',
+      provider: 'Groq',
+      maxTokenAllowed: 128000,
+      maxCompletionTokens: 8192,
+    },
 
     // Llama 3.3 70B: 128k context, most capable model
     {
@@ -25,6 +31,7 @@ export default class GroqProvider extends BaseProvider {
       label: 'Llama 3.3 70B',
       provider: 'Groq',
       maxTokenAllowed: 128000,
+      maxCompletionTokens: 8192,
     },
   ];
 
@@ -62,6 +69,7 @@ export default class GroqProvider extends BaseProvider {
       label: `${m.id} - context ${m.context_window ? Math.floor(m.context_window / 1000) + 'k' : 'N/A'} [ by ${m.owned_by}]`,
       provider: this.name,
       maxTokenAllowed: Math.min(m.context_window || 8192, 16384),
+      maxCompletionTokens: 8192,
     }));
   }
 

--- a/app/lib/modules/llm/providers/mistral.ts
+++ b/app/lib/modules/llm/providers/mistral.ts
@@ -13,15 +13,69 @@ export default class MistralProvider extends BaseProvider {
   };
 
   staticModels: ModelInfo[] = [
-    { name: 'open-mistral-7b', label: 'Mistral 7B', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'open-mixtral-8x7b', label: 'Mistral 8x7B', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'open-mixtral-8x22b', label: 'Mistral 8x22B', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'open-codestral-mamba', label: 'Codestral Mamba', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'open-mistral-nemo', label: 'Mistral Nemo', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'ministral-8b-latest', label: 'Mistral 8B', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'mistral-small-latest', label: 'Mistral Small', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'codestral-latest', label: 'Codestral', provider: 'Mistral', maxTokenAllowed: 8000 },
-    { name: 'mistral-large-latest', label: 'Mistral Large Latest', provider: 'Mistral', maxTokenAllowed: 8000 },
+    {
+      name: 'open-mistral-7b',
+      label: 'Mistral 7B',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'open-mixtral-8x7b',
+      label: 'Mistral 8x7B',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'open-mixtral-8x22b',
+      label: 'Mistral 8x22B',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'open-codestral-mamba',
+      label: 'Codestral Mamba',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'open-mistral-nemo',
+      label: 'Mistral Nemo',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'ministral-8b-latest',
+      label: 'Mistral 8B',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'mistral-small-latest',
+      label: 'Mistral Small',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'codestral-latest',
+      label: 'Codestral',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      name: 'mistral-large-latest',
+      label: 'Mistral Large Latest',
+      provider: 'Mistral',
+      maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
+    },
   ];
 
   getModelInstance(options: {

--- a/app/lib/modules/llm/providers/openai.ts
+++ b/app/lib/modules/llm/providers/openai.ts
@@ -79,11 +79,26 @@ export default class OpenAIProvider extends BaseProvider {
         contextWindow = 16385; // GPT-3.5-turbo has 16k context
       }
 
+      // Determine completion token limits based on model type
+      let maxCompletionTokens = 16384; // default for most models
+
+      if (m.id?.startsWith('o1-preview') || m.id?.startsWith('o1-mini') || m.id?.startsWith('o1')) {
+        // Reasoning models have specific completion limits
+        maxCompletionTokens = m.id?.includes('mini') ? 8192 : 16384;
+      } else if (m.id?.includes('gpt-4o')) {
+        maxCompletionTokens = 16384;
+      } else if (m.id?.includes('gpt-4')) {
+        maxCompletionTokens = 8192;
+      } else if (m.id?.includes('gpt-3.5-turbo')) {
+        maxCompletionTokens = 4096;
+      }
+
       return {
         name: m.id,
         label: `${m.id} (${Math.floor(contextWindow / 1000)}k context)`,
         provider: this.name,
         maxTokenAllowed: Math.min(contextWindow, 128000), // Cap at 128k for safety
+        maxCompletionTokens,
       };
     });
   }

--- a/app/lib/modules/llm/providers/openai.ts
+++ b/app/lib/modules/llm/providers/openai.ts
@@ -17,10 +17,16 @@ export default class OpenAIProvider extends BaseProvider {
      * Essential fallback models - only the most stable/reliable ones
      * GPT-4o: 128k context, high performance, recommended for most tasks
      */
-    { name: 'gpt-4o', label: 'GPT-4o', provider: 'OpenAI', maxTokenAllowed: 128000 },
+    { name: 'gpt-4o', label: 'GPT-4o', provider: 'OpenAI', maxTokenAllowed: 128000, maxCompletionTokens: 16384 },
 
     // GPT-3.5-turbo: 16k context, fast and cost-effective
-    { name: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', provider: 'OpenAI', maxTokenAllowed: 16000 },
+    {
+      name: 'gpt-3.5-turbo',
+      label: 'GPT-3.5 Turbo',
+      provider: 'OpenAI',
+      maxTokenAllowed: 16000,
+      maxCompletionTokens: 4096,
+    },
   ];
 
   async getDynamicModels(

--- a/app/lib/modules/llm/providers/together.ts
+++ b/app/lib/modules/llm/providers/together.ts
@@ -22,6 +22,7 @@ export default class TogetherProvider extends BaseProvider {
       label: 'Llama 3.2 90B Vision',
       provider: 'Together',
       maxTokenAllowed: 128000,
+      maxCompletionTokens: 8192,
     },
 
     // Mixtral 8x7B: 32k context, strong performance
@@ -30,6 +31,7 @@ export default class TogetherProvider extends BaseProvider {
       label: 'Mixtral 8x7B Instruct',
       provider: 'Together',
       maxTokenAllowed: 32000,
+      maxCompletionTokens: 8192,
     },
   ];
 
@@ -67,6 +69,7 @@ export default class TogetherProvider extends BaseProvider {
       label: `${m.display_name} - in:$${m.pricing.input.toFixed(2)} out:$${m.pricing.output.toFixed(2)} - context ${Math.floor(m.context_length / 1000)}k`,
       provider: this.name,
       maxTokenAllowed: 8000,
+      maxCompletionTokens: 8192,
     }));
   }
 

--- a/app/lib/modules/llm/types.ts
+++ b/app/lib/modules/llm/types.ts
@@ -5,7 +5,12 @@ export interface ModelInfo {
   name: string;
   label: string;
   provider: string;
+
+  /** Maximum context window size (input tokens) - how many tokens the model can process */
   maxTokenAllowed: number;
+
+  /** Maximum completion/output tokens - how many tokens the model can generate. If not specified, falls back to provider defaults */
+  maxCompletionTokens?: number;
 }
 
 export interface ProviderInfo {


### PR DESCRIPTION
Fix maxCompletionTokens Implementation for All Providers
 - Cohere: Added maxCompletionTokens: 4000 to all 10 static models
  - DeepSeek: Added maxCompletionTokens: 8192 to all 3 static models
  - Groq: Added maxCompletionTokens: 8192 to both static models
  - Mistral: Added maxCompletionTokens: 8192 to all 9 static models
  - Together: Added maxCompletionTokens: 8192 to both static models

  - Groq: Fixed getDynamicModels to include maxCompletionTokens: 8192
  - Together: Fixed getDynamicModels to include maxCompletionTokens: 8192
  - OpenAI: Fixed getDynamicModels with proper logic for reasoning models (o1: 16384, o1-mini: 8192) and standard models
