### PR TITLE
fix: security workflow to generate reports locally instead of uploadin…

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,7 +12,7 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
+  security-events: read
 
 jobs:
   codeql:
@@ -42,6 +42,16 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"
+          upload: false
+
+      - name: Upload CodeQL results as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: codeql-results-${{ matrix.language }}
+          path: |
+            **/results/**/*.sarif
+            **/results/**/*.sarif.json
 
   dependency-scan:
     name: Dependency Vulnerability Scan
@@ -75,6 +85,13 @@ jobs:
           format: spdx-json
           artifact-name: sbom.spdx.json
 
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sbom-results
+          path: sbom.spdx.json
+
   secrets-scan:
     name: Secrets Detection
     runs-on: ubuntu-latest
@@ -94,8 +111,10 @@ jobs:
           output: 'trivy-secrets-results.sarif'
           scanners: 'secret'
 
-      - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload Trivy secrets results as artifact
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          sarif_file: 'trivy-secrets-results.sarif'
+          name: trivy-secrets-results
+          path: trivy-secrets-results.sarif
+


### PR DESCRIPTION
 ✅ Issues Successfully Resolved

  1. Permission Error Fixed: Changed security-events: write to security-events: read (line 15), which
  removes the upload permissions that were causing the integration errors.
  2. CodeQL Upload Disabled: Added upload: false to the CodeQL analysis step (line 45), preventing
  automatic SARIF uploads that require write permissions.
  3. Trivy Upload Step Removed: The problematic github/codeql-action/upload-sarif@v3 step that was
  causing the "Resource not accessible by integration" errors has been completely removed.

  ✅ Workflow Quality

  The workflow maintains comprehensive security scanning:
  - CodeQL analysis for JavaScript/TypeScript
  - Dependency vulnerability scanning with npm audit
  - SBOM generation for supply chain security
  - Secrets detection with Trivy

  Benefits of Your Approach

  1. No Permission Issues: Artifacts don't require special GitHub permissions
  2. Results Still Accessible: Security teams can download and review all scan results
  3. CI/CD Doesn't Break: Workflow runs successfully without integration errors
  4. Comprehensive Coverage: All security scan types are preserved