### PR TITLE
fix: add id-token write permission to Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   packages: write
   contents: read
+  id-token: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
- Add id-token: write permission to enable OIDC authentication
- Required for pushing Docker images to external registries like gchr
- Fixes failing Docker builds during semantic releases

Closes #1954