### PR TITLE
feat: add support for OPENAI_LIKE_API_MODELS

### DIFF
--- a/app/types/model.ts
+++ b/app/types/model.ts
@@ -17,6 +17,7 @@ export type ProviderInfo = {
 export interface IProviderSetting {
   enabled?: boolean;
   baseUrl?: string;
+  OPENAI_LIKE_API_MODELS?: string;
 }
 
 export type IProviderConfig = ProviderInfo & {

--- a/vite-electron.config.ts
+++ b/vite-electron.config.ts
@@ -60,6 +60,7 @@ export default defineConfig((config) => {
     envPrefix: [
       'VITE_',
       'OPENAI_LIKE_API_BASE_URL',
+      'OPENAI_LIKE_API_MODELS',
       'OLLAMA_API_BASE_URL',
       'LMSTUDIO_API_BASE_URL',
       'TOGETHER_API_BASE_URL',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,7 @@ export default defineConfig((config) => {
     envPrefix: [
       'VITE_',
       'OPENAI_LIKE_API_BASE_URL',
+      'OPENAI_LIKE_API_MODELS',
       'OLLAMA_API_BASE_URL',
       'LMSTUDIO_API_BASE_URL',
       'TOGETHER_API_BASE_URL',

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9,6 +9,7 @@ interface Env {
   OLLAMA_API_BASE_URL: string;
   OPENAI_LIKE_API_KEY: string;
   OPENAI_LIKE_API_BASE_URL: string;
+  OPENAI_LIKE_API_MODELS: string;
   TOGETHER_API_KEY: string;
   TOGETHER_API_BASE_URL: string;
   DEEPSEEK_API_KEY: string;


### PR DESCRIPTION
- Add OPENAI_LIKE_API_MODELS environment variable support
- Enable fallback model parsing when /models endpoint fails
- Support providers like Fireworks AI that don't allow /models requests
- Format: path/to/model1:limit;path/to/model2:limit;path/to/model3:limit
- Update IProviderSetting interface to include OPENAI_LIKE_API_MODELS property
- Fix all linting errors and code formatting issues