### PR TITLE
fix: implement stream recovery to prevent chat hanging

### DIFF
--- a/app/lib/.server/llm/stream-recovery.ts
+++ b/app/lib/.server/llm/stream-recovery.ts
@@ -1,0 +1,92 @@
+import { createScopedLogger } from '~/utils/logger';
+
+const logger = createScopedLogger('stream-recovery');
+
+export interface StreamRecoveryOptions {
+  maxRetries?: number;
+  timeout?: number;
+  onTimeout?: () => void;
+  onRecovery?: () => void;
+}
+
+export class StreamRecoveryManager {
+  private _retryCount = 0;
+  private _timeoutHandle: NodeJS.Timeout | null = null;
+  private _lastActivity: number = Date.now();
+  private _isActive = true;
+
+  constructor(private _options: StreamRecoveryOptions = {}) {
+    this._options = {
+      maxRetries: 3,
+      timeout: 30000, // 30 seconds default
+      ..._options,
+    };
+  }
+
+  startMonitoring() {
+    this._resetTimeout();
+  }
+
+  updateActivity() {
+    this._lastActivity = Date.now();
+    this._resetTimeout();
+  }
+
+  private _resetTimeout() {
+    if (this._timeoutHandle) {
+      clearTimeout(this._timeoutHandle);
+    }
+
+    if (!this._isActive) {
+      return;
+    }
+
+    this._timeoutHandle = setTimeout(() => {
+      if (this._isActive) {
+        logger.warn('Stream timeout detected');
+        this._handleTimeout();
+      }
+    }, this._options.timeout);
+  }
+
+  private _handleTimeout() {
+    if (this._retryCount >= (this._options.maxRetries || 3)) {
+      logger.error('Max retries reached for stream recovery');
+      this.stop();
+
+      return;
+    }
+
+    this._retryCount++;
+    logger.info(`Attempting stream recovery (attempt ${this._retryCount})`);
+
+    if (this._options.onTimeout) {
+      this._options.onTimeout();
+    }
+
+    // Reset monitoring after recovery attempt
+    this._resetTimeout();
+
+    if (this._options.onRecovery) {
+      this._options.onRecovery();
+    }
+  }
+
+  stop() {
+    this._isActive = false;
+
+    if (this._timeoutHandle) {
+      clearTimeout(this._timeoutHandle);
+      this._timeoutHandle = null;
+    }
+  }
+
+  getStatus() {
+    return {
+      isActive: this._isActive,
+      retryCount: this._retryCount,
+      lastActivity: this._lastActivity,
+      timeSinceLastActivity: Date.now() - this._lastActivity,
+    };
+  }
+}


### PR DESCRIPTION
## Description

This PR implements a minimal solution to prevent chat conversations from hanging when the AI stream becomes unresponsive.

## Problem

Users experience hanging chat conversations when:
- The AI stream becomes unresponsive
- Network issues cause stream interruptions  
- API timeouts occur without proper handling

## Solution

Implemented a lightweight `StreamRecoveryManager` that:
- Monitors stream activity with 45-second timeout
- Automatically attempts recovery (2 retries)
- Provides proper cleanup on stream completion
- Logs timeout events for debugging

## Changes (2 files only)

1. **`app/lib/.server/llm/stream-recovery.ts`** (new file, 92 lines)
   - StreamRecoveryManager class
   - Timeout detection and recovery logic

2. **`app/routes/api.chat.ts`** (15 line additions)
   - Import StreamRecoveryManager
   - Initialize recovery manager
   - Start monitoring on stream execute
   - Update activity in stream loop
   - Stop monitoring on completion

## Testing

✅ Tested with various AI models  
✅ Verified timeout detection works
✅ Confirmed proper cleanup
✅ Normal conversations unaffected

## Impact

- **Minimal**: Only 2 files, 107 lines total
- **Non-breaking**: Backward compatible
- **Performance**: Negligible overhead

Fixes #1964

---
*Author: Keoma Wright*