### PR TITLE
fix: when Bolt run on wrangler there are not default User-Agent headers when request to Github are made

### DIFF
--- a/app/routes/api.system.git-info.ts
+++ b/app/routes/api.system.git-info.ts
@@ -120,6 +120,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
           headers: {
             Accept: 'application/vnd.github.v3+json',
             Authorization: `Bearer ${token}`,
+            'User-Agent': 'BoltAi/1.0',
           },
         });
 
@@ -146,6 +147,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
           headers: {
             Accept: 'application/vnd.github.v3+json',
             Authorization: `Bearer ${token}`,
+            'User-Agent': 'BoltAi/1.0',
           },
         });
 
@@ -161,6 +163,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
           headers: {
             Accept: 'application/vnd.github.v3+json',
             Authorization: `Bearer ${token}`,
+            'User-Agent': 'BoltAi/1.0',
           },
         });
 
@@ -189,6 +192,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
            *       headers: {
            *         Accept: 'application/vnd.github.v3+json',
            *         Authorization: `Bearer ${token}`,
+           *         'User-Agent': 'BoltAi/1.0',
            *       },
            *     });
            *
@@ -229,6 +233,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
           headers: {
             Accept: 'application/vnd.github.v3+json',
             Authorization: `Bearer ${token}`,
+            'User-Agent': 'BoltAi/1.0',
           },
         });
 
@@ -275,6 +280,7 @@ export const loader: LoaderFunction = async ({ request, context }: LoaderFunctio
           headers: {
             Accept: 'application/vnd.github.v3+json',
             Authorization: `Bearer ${token}`,
+            'User-Agent': 'BoltAi/1.0',
           },
         });
 


### PR DESCRIPTION
  **Local Development (pnpm run dev)**

Node.js runtime: Automatically adds a default User-Agent header like node-fetch/X.X.X or similar

Automatic headers: Node.js HTTP libraries include standard headers that GitHub API accepts

Permissive: GitHub API is more lenient with requests from development environments

  **Cloudflare Workers (Wrangler)**

V8 runtime: Uses the Web API fetch() **which doesn't automatically add User-Agent headers**

Stricter validation: GitHub API enforces User-Agent header requirements more strictly for production-like environments

Security: Cloudflare Workers strip or modify certain headers for security reasons