### PR TITLE
feat(local): add Docker Model Runner (DMR) local provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,10 @@ HYPERBOLIC_API_BASE_URL=https://api.hyperbolic.xyz/v1/chat/completions
 # USE: http://127.0.0.1:1234
 LMSTUDIO_API_BASE_URL=http://127.0.0.1:1234
 
+# Docker Model Runner (DMR)
+# Default host TCP endpoint when Model Runner TCP is enabled in Docker Desktop
+DMR_API_BASE_URL=http://127.0.0.1:12434
+
 # ======================================
 # CLOUD SERVICES CONFIGURATION
 # ======================================

--- a/app/components/@settings/tabs/providers/local/SetupGuide.tsx
+++ b/app/components/@settings/tabs/providers/local/SetupGuide.tsx
@@ -449,6 +449,97 @@ function SetupGuide({ onBack }: { onBack: () => void }) {
         </CardContent>
       </Card>
 
+      {/* Docker Model Runner Setup Section */}
+      <Card className="bg-bolt-elements-background-depth-2 shadow-sm">
+        <CardHeader className="pb-6">
+          <div className="flex items-center gap-4">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-cyan-500/20 to-blue-500/20 flex items-center justify-center ring-1 ring-cyan-500/30">
+              <Server className="w-6 h-6 text-cyan-500" />
+            </div>
+            <div className="flex-1">
+              <h3 className="text-xl font-semibold text-bolt-elements-textPrimary">Docker Model Runner (DMR) Setup</h3>
+              <p className="text-sm text-bolt-elements-textSecondary">OpenAI-compatible API via Docker Desktop</p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Requirements */}
+          <div className="p-4 rounded-lg bg-bolt-elements-background-depth-3">
+            <h4 className="font-medium text-bolt-elements-textPrimary mb-2">Requirements</h4>
+            <ul className="text-sm text-bolt-elements-textSecondary list-disc list-inside space-y-1">
+              <li>Docker Desktop 4.41+ (Windows) or 4.40+ (macOS) or Docker Engine (Linux)</li>
+              <li>Enable GPU for Windows (NVIDIA drivers 576.57+) if using GPU models</li>
+            </ul>
+          </div>
+
+          {/* Enable DMR and TCP */}
+          <div className="space-y-4">
+            <h4 className="font-medium text-bolt-elements-textPrimary flex items-center gap-2">
+              <Settings className="w-4 h-4" />
+              1. Enable DMR + Host TCP (12434)
+            </h4>
+            <div className="text-xs bg-bolt-elements-background-depth-4 p-3 rounded font-mono text-bolt-elements-textPrimary space-y-2">
+              <div># Docker Desktop CLI</div>
+              <div>docker desktop enable model-runner --tcp 12434</div>
+            </div>
+            <p className="text-xs text-bolt-elements-textSecondary">Alternatively, enable in Docker Desktop: Settings → Features in development → Model Runner → Enable host-side TCP support.</p>
+          </div>
+
+          {/* Pull a model */}
+          <div className="space-y-4">
+            <h4 className="font-medium text-bolt-elements-textPrimary flex items-center gap-2">
+              <Download className="w-4 h-4" />
+              2. Pull a model
+            </h4>
+            <div className="text-xs bg-bolt-elements-background-depth-4 p-3 rounded font-mono text-bolt-elements-textPrimary space-y-1">
+              <div>docker model pull ai/smollm2</div>
+            </div>
+            <p className="text-xs text-bolt-elements-textSecondary">Models are pulled from Docker Hub and cached locally.</p>
+          </div>
+
+          {/* Verify API */}
+          <div className="space-y-4">
+            <h4 className="font-medium text-bolt-elements-textPrimary flex items-center gap-2">
+              <Terminal className="w-4 h-4" />
+              3. Verify OpenAI-compatible API
+            </h4>
+            <div className="text-xs bg-bolt-elements-background-depth-4 p-3 rounded font-mono text-bolt-elements-textPrimary space-y-1">
+              <div># List models</div>
+              <div>curl http://localhost:12434/engines/v1/models</div>
+              <div></div>
+              <div># Create chat completion</div>
+              <div>{`curl http://localhost:12434/engines/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"ai/smollm2","messages":[{"role":"user","content":"hello"}]}'`}</div>
+            </div>
+            <p className="text-xs text-bolt-elements-textSecondary">From containers, use http://model-runner.docker.internal/engines/v1/…</p>
+          </div>
+
+          {/* Configure in Bolt DIY */}
+          <div className="space-y-4">
+            <h4 className="font-medium text-bolt-elements-textPrimary flex items-center gap-2">
+              <Globe className="w-4 h-4" />
+              4. Configure in Bolt DIY
+            </h4>
+            <ul className="text-sm text-bolt-elements-textSecondary list-disc list-inside space-y-1">
+              <li>Enable provider: Settings → Providers → Local → Docker Model Runner</li>
+              <li>Base URL: http://127.0.0.1:12434 (we route to /engines/v1 automatically)</li>
+              <li>If Bolt runs in Docker, we automatically use host.docker.internal</li>
+            </ul>
+          </div>
+
+          {/* Known issues */}
+          <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+            <div className="flex items-center gap-2 mb-2">
+              <AlertCircle className="w-4 h-4 text-yellow-500" />
+              <span className="font-medium text-yellow-500">Known issues</span>
+            </div>
+            <ul className="text-xs text-bolt-elements-textSecondary space-y-1">
+              <li>docker: 'model' is not a docker command → ensure the plugin is detected by Docker Desktop.</li>
+              <li>Linux containers in Compose may need extra_hosts: "model-runner.docker.internal:host-gateway"</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
       {/* LocalAI Setup Section */}
       <Card className="bg-bolt-elements-background-depth-2 shadow-sm">
         <CardHeader className="pb-6">

--- a/app/components/@settings/tabs/providers/local/types.ts
+++ b/app/components/@settings/tabs/providers/local/types.ts
@@ -1,5 +1,8 @@
 // Type definitions
-export type ProviderName = 'Ollama' | 'LMStudio' | 'OpenAILike';
+import type { ComponentType } from 'react';
+import { Server, Monitor, Globe } from 'lucide-react';
+
+export type ProviderName = 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner';
 
 export interface OllamaModel {
   name: string;
@@ -31,14 +34,16 @@ export interface LMStudioModel {
 // Constants
 export const OLLAMA_API_URL = 'http://127.0.0.1:11434';
 
-export const PROVIDER_ICONS = {
-  Ollama: 'Server',
-  LMStudio: 'Monitor',
-  OpenAILike: 'Globe',
+export const PROVIDER_ICONS: Record<ProviderName, ComponentType<any>> = {
+  Ollama: Server,
+  LMStudio: Monitor,
+  OpenAILike: Globe,
+  DockerModelRunner: Server,
 } as const;
 
 export const PROVIDER_DESCRIPTIONS = {
   Ollama: 'Run open-source models locally on your machine',
   LMStudio: 'Local model inference with LM Studio',
   OpenAILike: 'Connect to OpenAI-compatible API endpoints',
+  DockerModelRunner: 'Docker Desktop Model Runner with OpenAI-compatible API (/engines/v1)',
 } as const;

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -105,7 +105,7 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
       <div>
         <ClientOnly>
           {() => (
-            <div className={props.isModelSettingsCollapsed ? 'hidden' : ''}>
+            <div className={classNames(props.isModelSettingsCollapsed ? 'hidden' : '', 'mb-2')}>
               <ModelSelector
                 key={props.provider?.name + ':' + props.modelList.length}
                 model={props.model}

--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -573,7 +573,15 @@ export const ModelSelector = ({
       </div>
 
       {/* Model Combobox */}
-      <div className="relative flex w-full min-w-[70%]" onKeyDown={handleModelKeyDown} ref={modelDropdownRef}>
+      <div
+        className={classNames(
+          'relative flex w-full',
+          // Prevent overflow when provider name is long (e.g., DockerModelRunner)
+          provider?.name === 'DockerModelRunner' ? 'min-w-0 sm:min-w-[60%]' : 'min-w-[70%]'
+        )}
+        onKeyDown={handleModelKeyDown}
+        ref={modelDropdownRef}
+      >
         <div
           className={classNames(
             'w-full p-2 rounded-lg border border-bolt-elements-borderColor',

--- a/app/lib/hooks/useLocalModelHealth.ts
+++ b/app/lib/hooks/useLocalModelHealth.ts
@@ -8,11 +8,11 @@ export interface UseLocalModelHealthOptions {
 
 export interface UseLocalModelHealthReturn {
   healthStatuses: ModelHealthStatus[];
-  getHealthStatus: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => ModelHealthStatus | undefined;
-  startMonitoring: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string, checkInterval?: number) => void;
-  stopMonitoring: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => void;
-  performHealthCheck: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => Promise<void>;
-  isHealthy: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => boolean;
+  getHealthStatus: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => ModelHealthStatus | undefined;
+  startMonitoring: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string, checkInterval?: number) => void;
+  stopMonitoring: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => void;
+  performHealthCheck: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => Promise<void>;
+  isHealthy: (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => boolean;
   getOverallHealth: () => { healthy: number; unhealthy: number; checking: number; unknown: number };
 }
 
@@ -51,13 +51,13 @@ export function useLocalModelHealth(options: UseLocalModelHealthOptions = {}): U
   }, []);
 
   // Get health status for a specific provider
-  const getHealthStatus = useCallback((provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => {
+const getHealthStatus = useCallback((provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => {
     return localModelHealthMonitor.getHealthStatus(provider, baseUrl);
   }, []);
 
   // Start monitoring a provider
-  const startMonitoring = useCallback(
-    (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string, interval?: number) => {
+const startMonitoring = useCallback(
+    (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string, interval?: number) => {
       console.log(`[Health Monitor] Starting monitoring for ${provider} at ${baseUrl}`);
       localModelHealthMonitor.startMonitoring(provider, baseUrl, interval || checkInterval);
     },
@@ -65,7 +65,7 @@ export function useLocalModelHealth(options: UseLocalModelHealthOptions = {}): U
   );
 
   // Stop monitoring a provider
-  const stopMonitoring = useCallback((provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => {
+const stopMonitoring = useCallback((provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => {
     console.log(`[Health Monitor] Stopping monitoring for ${provider} at ${baseUrl}`);
     localModelHealthMonitor.stopMonitoring(provider, baseUrl);
 
@@ -74,13 +74,13 @@ export function useLocalModelHealth(options: UseLocalModelHealthOptions = {}): U
   }, []);
 
   // Perform manual health check
-  const performHealthCheck = useCallback(async (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => {
+const performHealthCheck = useCallback(async (provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => {
     await localModelHealthMonitor.performHealthCheck(provider, baseUrl);
   }, []);
 
   // Check if a provider is healthy
   const isHealthy = useCallback(
-    (provider: 'Ollama' | 'LMStudio' | 'OpenAILike', baseUrl: string) => {
+(provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner', baseUrl: string) => {
       const status = getHealthStatus(provider, baseUrl);
       return status?.status === 'healthy';
     },
@@ -113,7 +113,7 @@ export function useLocalModelHealth(options: UseLocalModelHealthOptions = {}): U
  * Hook for monitoring a specific provider
  */
 export function useProviderHealth(
-  provider: 'Ollama' | 'LMStudio' | 'OpenAILike',
+  provider: 'Ollama' | 'LMStudio' | 'OpenAILike' | 'DockerModelRunner',
   baseUrl: string,
   options: UseLocalModelHealthOptions = {},
 ) {

--- a/app/lib/modules/llm/providers/docker-model-runner.ts
+++ b/app/lib/modules/llm/providers/docker-model-runner.ts
@@ -1,0 +1,115 @@
+import { BaseProvider } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { logger } from '~/utils/logger';
+
+export default class DockerModelRunnerProvider extends BaseProvider {
+  name = 'DockerModelRunner';
+  getApiKeyLink = 'https://docs.docker.com/ai/model-runner/';
+  labelForGetApiKey = 'Enable Model Runner';
+  icon = 'i-ph:docker-logo';
+
+  config = {
+    baseUrlKey: 'DMR_API_BASE_URL',
+    baseUrl: 'http://localhost:12434',
+  };
+
+  staticModels: ModelInfo[] = [];
+
+  private _normalizeBaseUrl(baseUrl: string, isDocker: boolean): string {
+    let url = baseUrl;
+
+    if (isDocker) {
+      url = url.replace('localhost', 'host.docker.internal');
+      url = url.replace('127.0.0.1', 'host.docker.internal');
+    }
+
+    if (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+
+    return url;
+  }
+
+  async getDynamicModels(
+    apiKeys?: Record<string, string>,
+    settings?: IProviderSetting,
+    serverEnv: Record<string, string> = {},
+  ): Promise<ModelInfo[]> {
+    let { baseUrl } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: settings,
+      serverEnv,
+      defaultBaseUrlKey: 'DMR_API_BASE_URL',
+      defaultApiTokenKey: '',
+    });
+
+    if (!baseUrl) {
+      throw new Error('No baseUrl found for Docker Model Runner provider');
+    }
+
+    const isDocker = process?.env?.RUNNING_IN_DOCKER === 'true' || serverEnv?.RUNNING_IN_DOCKER === 'true';
+    const normalized = this._normalizeBaseUrl(baseUrl, !!isDocker);
+
+    const modelsUrl = `${normalized}/engines/v1/models`;
+
+    const response = await fetch(modelsUrl);
+
+    if (!response.ok) {
+      throw new Error(`DMR GET /engines/v1/models failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as { data?: Array<{ id: string }>; [key: string]: any };
+    const items = data?.data || [];
+
+    return items.map((m) => ({
+      name: m.id,
+      label: m.id,
+      provider: this.name,
+      maxTokenAllowed: 8000,
+    }));
+  }
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv?: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    let { baseUrl } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: 'DMR_API_BASE_URL',
+      defaultApiTokenKey: '',
+    });
+
+    if (!baseUrl) {
+      throw new Error('No baseUrl found for Docker Model Runner provider');
+    }
+
+    const envRecord = Object.entries(serverEnv || ({} as any)).reduce(
+      (acc, [k, v]) => {
+        acc[k] = String(v);
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+
+    const isDocker = process?.env?.RUNNING_IN_DOCKER === 'true' || envRecord?.RUNNING_IN_DOCKER === 'true';
+    const normalized = this._normalizeBaseUrl(baseUrl, !!isDocker);
+
+    logger.debug('Docker Model Runner Base Url used: ', normalized);
+
+    const openai = createOpenAI({
+      baseURL: `${normalized}/engines/v1`,
+      apiKey: '',
+    });
+
+    return openai(model);
+  }
+}

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -17,6 +17,7 @@ import HyperbolicProvider from './providers/hyperbolic';
 import AmazonBedrockProvider from './providers/amazon-bedrock';
 import GithubProvider from './providers/github';
 import MoonshotProvider from './providers/moonshot';
+import DockerModelRunnerProvider from './providers/docker-model-runner';
 
 export {
   AnthropicProvider,
@@ -38,4 +39,5 @@ export {
   LMStudioProvider,
   AmazonBedrockProvider,
   GithubProvider,
+  DockerModelRunnerProvider,
 };

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -23,8 +23,8 @@ export interface Shortcuts {
   toggleTerminal: Shortcut;
 }
 
-export const URL_CONFIGURABLE_PROVIDERS = ['Ollama', 'LMStudio', 'OpenAILike'];
-export const LOCAL_PROVIDERS = ['OpenAILike', 'LMStudio', 'Ollama'];
+export const URL_CONFIGURABLE_PROVIDERS = ['Ollama', 'LMStudio', 'OpenAILike', 'DockerModelRunner'];
+export const LOCAL_PROVIDERS = ['OpenAILike', 'LMStudio', 'Ollama', 'DockerModelRunner'];
 
 export type ProviderSetting = Record<string, IProviderConfig>;
 

--- a/app/routes/api.local-proxy.ts
+++ b/app/routes/api.local-proxy.ts
@@ -1,0 +1,82 @@
+import { json } from '@remix-run/cloudflare';
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/cloudflare';
+
+// Very small proxy to access local services (LM Studio, Ollama, Docker Model Runner)
+// from the browser without running into CORS. Restricted to localhost-style hosts.
+
+const ALLOWED_HOSTS = new Set([
+  '127.0.0.1',
+  'localhost',
+  '0.0.0.0',
+  'host.docker.internal',
+  'model-runner.docker.internal',
+]);
+
+const CORS_HEADERS: HeadersInit = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'content-type,authorization',
+  'Access-Control-Max-Age': '86400',
+};
+
+function isAllowed(urlStr: string): boolean {
+  try {
+    const url = new URL(urlStr);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && ALLOWED_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function handle(request: Request) {
+  const url = new URL(request.url);
+  const target = url.searchParams.get('url');
+
+  // Preflight
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 200, headers: CORS_HEADERS });
+  }
+
+  if (!target || !isAllowed(target)) {
+    return json({ error: 'Invalid or disallowed target URL' }, { status: 400, headers: CORS_HEADERS });
+  }
+
+  try {
+    const init: RequestInit = {
+      method: request.method,
+      headers: { 'Content-Type': request.headers.get('Content-Type') || 'application/json' },
+    };
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      init.body = request.body;
+      // @ts-ignore - duplex is required by some runtimes for streaming bodies
+      init.duplex = 'half';
+    }
+
+    const resp = await fetch(target, init);
+
+    const headers = new Headers(CORS_HEADERS);
+    // Pass through content type if present
+    const contentType = resp.headers.get('content-type');
+    if (contentType) headers.set('content-type', contentType);
+
+    return new Response(resp.body, {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers,
+    });
+  } catch (err) {
+    return json({ error: 'Proxy request failed', message: err instanceof Error ? err.message : String(err) }, {
+      status: 502,
+      headers: CORS_HEADERS,
+    });
+  }
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return handle(request);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  return handle(request);
+}


### PR DESCRIPTION
feat(local): add Docker Model Runner (DMR) local provider support

- Introduce Docker Model Runner as a new local provider with base URL config
- Implement health monitoring integration for DMR in local model health hooks
- Add model fetching logic for DMR with local proxy to bypass CORS
- Display available Docker Model Runner models in local providers tab UI
- Create a setup guide section detailing DMR setup, requirements, and usage
- Extend provider types, icons, and descriptions to include DMR
- Update local provider settings and registry to support DMR
- Enhance ModelSelector UI to handle long provider names like DockerModelRunner
- Modify localModelHealthMonitor service to support health checks for DMR provider