### PR TITLE
fix: update Docker workflow target to match new Dockerfile structure

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          target: bolt-ai-production
+          target: runtime
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

This PR fixes a critical issue in the Docker workflow where the build target doesn't match the actual Dockerfile structure, causing production deployment failures.

### Issue

The `docker.yaml` workflow was trying to build:
- ❌ `target: bolt-ai-production` (doesn't exist in current Dockerfile)

### Fix

Updated to use the correct target name:
- ✅ `target: runtime` (matches actual Dockerfile stage)

### Current Dockerfile Structure

The Dockerfile has these stages:
1. `build` - Build stage with dependencies and compilation
2. `runtime` - Production runtime stage ⭐ **(This is what we need)**
3. `development` - Development stage with dev tools

### Impact

**Before**: Docker builds would fail with `ERROR: target stage "bolt-ai-production" could not be found`
**After**: Docker builds succeed using the correct `runtime` target

### Testing

This fix ensures:
- ✅ Production Docker builds work correctly
- ✅ Container deployments succeed 
- ✅ CI/CD pipeline doesn't break on Docker builds
- ✅ Matches the fixes already applied to CI validation

### Related

This complements PR #1999 which fixed the Dockerfile syntax errors and added Docker build validation to CI.