### PR TITLE
fix(deploy): netlify deploy error visibility and uploads

### DIFF
--- a/app/components/deploy/GitHubDeploy.client.tsx
+++ b/app/components/deploy/GitHubDeploy.client.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import type { ActionCallbackData } from '~/lib/runtime/message-parser';
 import { chatId } from '~/lib/persistence/useChatHistory';
 import { getLocalStorage } from '~/lib/persistence/localStorage';
+import { formatBuildFailureOutput } from './deployUtils';
 
 export function useGitHubDeploy() {
   const [isDeploying, setIsDeploying] = useState(false);
@@ -65,10 +66,12 @@ export function useGitHubDeploy() {
       // Then run it
       await artifact.runner.runAction(actionData);
 
-      if (!artifact.runner.buildOutput) {
+      const buildOutput = artifact.runner.buildOutput;
+
+      if (!buildOutput || buildOutput.exitCode !== 0) {
         // Notify that build failed
         deployArtifact.runner.handleDeployAction('building', 'failed', {
-          error: 'Build failed. Check the terminal for details.',
+          error: formatBuildFailureOutput(buildOutput?.output),
           source: 'github',
         });
         throw new Error('Build failed');

--- a/app/components/deploy/GitLabDeploy.client.tsx
+++ b/app/components/deploy/GitLabDeploy.client.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import type { ActionCallbackData } from '~/lib/runtime/message-parser';
 import { chatId } from '~/lib/persistence/useChatHistory';
 import { getLocalStorage } from '~/lib/persistence/localStorage';
+import { formatBuildFailureOutput } from './deployUtils';
 
 export function useGitLabDeploy() {
   const [isDeploying, setIsDeploying] = useState(false);
@@ -65,10 +66,12 @@ export function useGitLabDeploy() {
       // Then run it
       await artifact.runner.runAction(actionData);
 
-      if (!artifact.runner.buildOutput) {
+      const buildOutput = artifact.runner.buildOutput;
+
+      if (!buildOutput || buildOutput.exitCode !== 0) {
         // Notify that build failed
         deployArtifact.runner.handleDeployAction('building', 'failed', {
-          error: 'Build failed. Check the terminal for details.',
+          error: formatBuildFailureOutput(buildOutput?.output),
           source: 'gitlab',
         });
         throw new Error('Build failed');

--- a/app/components/deploy/VercelDeploy.client.tsx
+++ b/app/components/deploy/VercelDeploy.client.tsx
@@ -7,6 +7,7 @@ import { path } from '~/utils/path';
 import { useState } from 'react';
 import type { ActionCallbackData } from '~/lib/runtime/message-parser';
 import { chatId } from '~/lib/persistence/useChatHistory';
+import { formatBuildFailureOutput } from './deployUtils';
 
 export function useVercelDeploy() {
   const [isDeploying, setIsDeploying] = useState(false);
@@ -64,10 +65,12 @@ export function useVercelDeploy() {
       // Then run it
       await artifact.runner.runAction(actionData);
 
-      if (!artifact.runner.buildOutput) {
+      const buildOutput = artifact.runner.buildOutput;
+
+      if (!buildOutput || buildOutput.exitCode !== 0) {
         // Notify that build failed
         deployArtifact.runner.handleDeployAction('building', 'failed', {
-          error: 'Build failed. Check the terminal for details.',
+          error: formatBuildFailureOutput(buildOutput?.output),
           source: 'vercel',
         });
         throw new Error('Build failed');
@@ -80,7 +83,7 @@ export function useVercelDeploy() {
       const container = await webcontainer;
 
       // Remove /home/project from buildPath if it exists
-      const buildPath = artifact.runner.buildOutput.path.replace('/home/project', '');
+      const buildPath = buildOutput.path.replace('/home/project', '');
 
       // Check if the build path exists
       let finalBuildPath = buildPath;

--- a/app/components/deploy/deployUtils.ts
+++ b/app/components/deploy/deployUtils.ts
@@ -1,0 +1,15 @@
+const MAX_BUILD_OUTPUT_CHARS = 4000;
+
+export function formatBuildFailureOutput(output?: string) {
+  const trimmed = output?.trim();
+
+  if (!trimmed) {
+    return 'Build failed with no output captured.';
+  }
+
+  if (trimmed.length <= MAX_BUILD_OUTPUT_CHARS) {
+    return trimmed;
+  }
+
+  return `Build output (truncated):\n${trimmed.slice(-MAX_BUILD_OUTPUT_CHARS)}`;
+}


### PR DESCRIPTION
## Summary
- capture build output and surface it in deploy errors instead of “check terminal”
- improve Netlify deploy API error details and upload behavior
- align deploy flows to handle non-zero build exit codes consistently

## Testing
- pnpm typecheck
- pnpm lint

Fixes #2084
