### PR TITLE
fix: improve local model provider robustness and UX

### DIFF
--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { ModelInfo } from '~/lib/modules/llm/types';
 import { classNames } from '~/utils/classNames';
+import { LOCAL_PROVIDERS } from '~/lib/stores/settings';
 
 // Fuzzy search utilities
 const levenshteinDistance = (str1: string, str2: string): number => {
@@ -129,6 +130,32 @@ export const ModelSelector = ({
   const providerOptionsRef = useRef<(HTMLDivElement | null)[]>([]);
   const providerDropdownRef = useRef<HTMLDivElement>(null);
   const [showFreeModelsOnly, setShowFreeModelsOnly] = useState(false);
+
+  type ConnectionStatus = 'unknown' | 'connected' | 'disconnected';
+
+  const [localProviderStatus, setLocalProviderStatus] = useState<Record<string, ConnectionStatus>>({});
+
+  // Check connectivity of local providers when provider list changes
+  useEffect(() => {
+    const checkLocalProviders = async () => {
+      const statuses: Record<string, 'connected' | 'disconnected'> = {};
+
+      for (const p of providerList) {
+        if (!LOCAL_PROVIDERS.includes(p.name)) {
+          continue;
+        }
+
+        // If the provider has models loaded, it's connected
+        const hasModels = modelList.some((m) => m.provider === p.name);
+
+        statuses[p.name] = hasModels ? 'connected' : 'disconnected';
+      }
+
+      setLocalProviderStatus(statuses);
+    };
+
+    checkLocalProviders();
+  }, [providerList, modelList]);
 
   // Debounce search queries
   useEffect(() => {
@@ -440,7 +467,28 @@ export const ModelSelector = ({
           tabIndex={0}
         >
           <div className="flex items-center justify-between">
-            <div className="truncate">{provider?.name || 'Select provider'}</div>
+            <div className="flex items-center gap-2 truncate">
+              {provider?.name && LOCAL_PROVIDERS.includes(provider.name) && (
+                <span
+                  className={classNames(
+                    'inline-block w-2 h-2 rounded-full flex-shrink-0',
+                    localProviderStatus[provider.name] === 'connected'
+                      ? 'bg-green-500'
+                      : localProviderStatus[provider.name] === 'disconnected'
+                        ? 'bg-red-400'
+                        : 'bg-bolt-elements-textTertiary',
+                  )}
+                  title={
+                    localProviderStatus[provider.name] === 'connected'
+                      ? `${provider.name} is running`
+                      : localProviderStatus[provider.name] === 'disconnected'
+                        ? `${provider.name} is not reachable`
+                        : 'Checking...'
+                  }
+                />
+              )}
+              {provider?.name || 'Select provider'}
+            </div>
             <div
               className={classNames(
                 'i-ph:caret-down w-4 h-4 text-bolt-elements-textSecondary opacity-75',
@@ -559,11 +607,25 @@ export const ModelSelector = ({
                     }}
                     tabIndex={focusedProviderIndex === index ? 0 : -1}
                   >
-                    <div
-                      dangerouslySetInnerHTML={{
-                        __html: (providerOption as any).highlightedName || providerOption.name,
-                      }}
-                    />
+                    <div className="flex items-center gap-2">
+                      {LOCAL_PROVIDERS.includes(providerOption.name) && (
+                        <span
+                          className={classNames(
+                            'inline-block w-2 h-2 rounded-full flex-shrink-0',
+                            localProviderStatus[providerOption.name] === 'connected'
+                              ? 'bg-green-500'
+                              : localProviderStatus[providerOption.name] === 'disconnected'
+                                ? 'bg-red-400'
+                                : 'bg-bolt-elements-textTertiary',
+                          )}
+                        />
+                      )}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: (providerOption as any).highlightedName || providerOption.name,
+                        }}
+                      />
+                    </div>
                   </div>
                 ))
               )}
@@ -717,8 +779,17 @@ export const ModelSelector = ({
                       ? `No models match "${debouncedModelSearchQuery}"${showFreeModelsOnly ? ' (free only)' : ''}`
                       : showFreeModelsOnly
                         ? 'No free models available'
-                        : 'No models available'}
+                        : provider?.name && LOCAL_PROVIDERS.includes(provider.name)
+                          ? `No models found — is ${provider.name} running?`
+                          : 'No models available'}
                   </div>
+                  {!debouncedModelSearchQuery && provider?.name && LOCAL_PROVIDERS.includes(provider.name) && (
+                    <div className="text-xs text-bolt-elements-textTertiary mt-1">
+                      Make sure {provider.name} is running and has at least one model loaded.
+                      {provider.name === 'Ollama' && ' Try: ollama pull llama3.2'}
+                      {provider.name === 'LMStudio' && ' Load a model in LM Studio first.'}
+                    </div>
+                  )}
                   {debouncedModelSearchQuery && (
                     <div className="text-xs text-bolt-elements-textTertiary">
                       Try searching for model names, context sizes (e.g., "128k", "1M"), or capabilities

--- a/app/lib/modules/llm/base-provider.ts
+++ b/app/lib/modules/llm/base-provider.ts
@@ -4,6 +4,9 @@ import type { IProviderSetting } from '~/types/model';
 import { createOpenAI } from '@ai-sdk/openai';
 import { LLMManager } from './manager';
 
+/** Default timeout for model listing API calls (5 seconds) */
+const MODEL_FETCH_TIMEOUT = 5_000;
+
 export abstract class BaseProvider implements ProviderInfo {
   abstract name: string;
   abstract staticModels: ModelInfo[];
@@ -16,6 +19,48 @@ export abstract class BaseProvider implements ProviderInfo {
   getApiKeyLink?: string;
   labelForGetApiKey?: string;
   icon?: string;
+
+  /**
+   * Convert Cloudflare Env bindings to a plain Record<string, string>.
+   * Useful because provider methods expect Record<string, string> but
+   * Cloudflare Workers pass an Env interface.
+   */
+  protected convertEnvToRecord(env?: Env): Record<string, string> {
+    if (!env) {
+      return {};
+    }
+
+    return Object.entries(env).reduce(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+  }
+
+  /**
+   * Rewrite localhost / 127.0.0.1 URLs to host.docker.internal when
+   * running inside Docker. Only applies on the server side.
+   */
+  protected resolveDockerUrl(baseUrl: string, serverEnv?: Record<string, string>): string {
+    const isDocker = process?.env?.RUNNING_IN_DOCKER === 'true' || serverEnv?.RUNNING_IN_DOCKER === 'true';
+
+    if (!isDocker) {
+      return baseUrl;
+    }
+
+    return baseUrl.replace('localhost', 'host.docker.internal').replace('127.0.0.1', 'host.docker.internal');
+  }
+
+  /**
+   * Create an AbortSignal that times out after the given milliseconds.
+   * Used to prevent model-listing fetches from hanging indefinitely.
+   */
+  protected createTimeoutSignal(ms: number = MODEL_FETCH_TIMEOUT): AbortSignal {
+    return AbortSignal.timeout(ms);
+  }
 
   getProviderBaseUrlAndKey(options: {
     apiKeys?: Record<string, string>;
@@ -59,7 +104,6 @@ export abstract class BaseProvider implements ProviderInfo {
     serverEnv?: Record<string, string>;
   }): ModelInfo[] | null {
     if (!this.cachedDynamicModels) {
-      // console.log('no dynamic models',this.name);
       return null;
     }
 
@@ -67,8 +111,8 @@ export abstract class BaseProvider implements ProviderInfo {
     const generatedCacheKey = this.getDynamicModelsCacheKey(options);
 
     if (cacheKey !== generatedCacheKey) {
-      // console.log('cache key mismatch',this.name,cacheKey,generatedCacheKey);
       this.cachedDynamicModels = undefined;
+
       return null;
     }
 
@@ -79,10 +123,20 @@ export abstract class BaseProvider implements ProviderInfo {
     providerSettings?: Record<string, IProviderSetting>;
     serverEnv?: Record<string, string>;
   }) {
+    // Only include provider-relevant env keys, not the entire server environment
+    const relevantEnvKeys = [this.config.baseUrlKey, this.config.apiTokenKey].filter(Boolean) as string[];
+    const relevantEnv: Record<string, string> = {};
+
+    for (const key of relevantEnvKeys) {
+      if (options.serverEnv?.[key]) {
+        relevantEnv[key] = options.serverEnv[key];
+      }
+    }
+
     return JSON.stringify({
       apiKeys: options.apiKeys?.[this.name],
       providerSettings: options.providerSettings?.[this.name],
-      serverEnv: options.serverEnv,
+      serverEnv: relevantEnv,
     });
   }
   storeDynamicModels(
@@ -95,7 +149,6 @@ export abstract class BaseProvider implements ProviderInfo {
   ) {
     const cacheId = this.getDynamicModelsCacheKey(options);
 
-    // console.log('caching dynamic models',this.name,cacheId);
     this.cachedDynamicModels = {
       cacheId,
       models,

--- a/app/lib/modules/llm/manager.ts
+++ b/app/lib/modules/llm/manager.ts
@@ -9,7 +9,7 @@ export class LLMManager {
   private static _instance: LLMManager;
   private _providers: Map<string, BaseProvider> = new Map();
   private _modelList: ModelInfo[] = [];
-  private readonly _env: any = {};
+  private _env: Record<string, string> = {};
 
   private constructor(_env: Record<string, string>) {
     this._registerProvidersFromDirectory();
@@ -19,6 +19,9 @@ export class LLMManager {
   static getInstance(env: Record<string, string> = {}): LLMManager {
     if (!LLMManager._instance) {
       LLMManager._instance = new LLMManager(env);
+    } else if (Object.keys(env).length > 0) {
+      // Update env on subsequent calls so Cloudflare Workers get fresh bindings
+      LLMManager._instance._env = env;
     }
 
     return LLMManager._instance;
@@ -121,10 +124,10 @@ export class LLMManager {
     const staticModels = Array.from(this._providers.values()).flatMap((p) => p.staticModels || []);
     const dynamicModelsFlat = dynamicModels.flat();
     const dynamicModelKeys = dynamicModelsFlat.map((d) => `${d.name}-${d.provider}`);
-    const filteredStaticModesl = staticModels.filter((m) => !dynamicModelKeys.includes(`${m.name}-${m.provider}`));
+    const filteredStaticModels = staticModels.filter((m) => !dynamicModelKeys.includes(`${m.name}-${m.provider}`));
 
     // Combine static and dynamic models
-    const modelList = [...dynamicModelsFlat, ...filteredStaticModesl];
+    const modelList = [...dynamicModelsFlat, ...filteredStaticModels];
     modelList.sort((a, b) => a.name.localeCompare(b.name));
     this._modelList = modelList;
 

--- a/app/lib/modules/llm/providers/lmstudio.ts
+++ b/app/lib/modules/llm/providers/lmstudio.ts
@@ -18,11 +18,11 @@ export default class LMStudioProvider extends BaseProvider {
 
   staticModels: ModelInfo[] = [];
 
-  async getDynamicModels(
+  private _resolveBaseUrl(
     apiKeys?: Record<string, string>,
     settings?: IProviderSetting,
-    serverEnv: Record<string, string> = {},
-  ): Promise<ModelInfo[]> {
+    serverEnv?: Record<string, string>,
+  ): string {
     let { baseUrl } = this.getProviderBaseUrlAndKey({
       apiKeys,
       providerSettings: settings,
@@ -35,27 +35,54 @@ export default class LMStudioProvider extends BaseProvider {
       throw new Error('No baseUrl found for LMStudio provider');
     }
 
-    if (typeof window === 'undefined') {
-      /*
-       * Running in Server
-       * Backend: Check if we're running in Docker
-       */
-      const isDocker = process?.env?.RUNNING_IN_DOCKER === 'true' || serverEnv?.RUNNING_IN_DOCKER === 'true';
+    baseUrl = this.resolveDockerUrl(baseUrl, serverEnv);
 
-      baseUrl = isDocker ? baseUrl.replace('localhost', 'host.docker.internal') : baseUrl;
-      baseUrl = isDocker ? baseUrl.replace('127.0.0.1', 'host.docker.internal') : baseUrl;
-    }
-
-    const response = await fetch(`${baseUrl}/v1/models`);
-    const data = (await response.json()) as { data: Array<{ id: string }> };
-
-    return data.data.map((model) => ({
-      name: model.id,
-      label: model.id,
-      provider: this.name,
-      maxTokenAllowed: 8000,
-    }));
+    return baseUrl;
   }
+
+  async getDynamicModels(
+    apiKeys?: Record<string, string>,
+    settings?: IProviderSetting,
+    serverEnv: Record<string, string> = {},
+  ): Promise<ModelInfo[]> {
+    const baseUrl = this._resolveBaseUrl(apiKeys, settings, serverEnv);
+
+    try {
+      const response = await fetch(`${baseUrl}/v1/models`, {
+        signal: this.createTimeoutSignal(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as { data: Array<{ id: string }> };
+
+      return data.data.map((model) => ({
+        name: model.id,
+        label: model.id,
+        provider: this.name,
+        maxTokenAllowed: 8000,
+      }));
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        logger.warn('LMStudio model fetch timed out — is LM Studio running?');
+
+        return [];
+      }
+
+      if (error instanceof TypeError && error.message.includes('fetch')) {
+        logger.warn(`LMStudio not reachable at ${baseUrl} — is LM Studio running?`);
+
+        return [];
+      }
+
+      logger.error('Error fetching LMStudio models:', error);
+
+      return [];
+    }
+  }
+
   getModelInstance: (options: {
     model: string;
     serverEnv?: Env;
@@ -63,24 +90,9 @@ export default class LMStudioProvider extends BaseProvider {
     providerSettings?: Record<string, IProviderSetting>;
   }) => LanguageModelV1 = (options) => {
     const { apiKeys, providerSettings, serverEnv, model } = options;
-    let { baseUrl } = this.getProviderBaseUrlAndKey({
-      apiKeys,
-      providerSettings: providerSettings?.[this.name],
-      serverEnv: serverEnv as any,
-      defaultBaseUrlKey: 'LMSTUDIO_API_BASE_URL',
-      defaultApiTokenKey: '',
-    });
+    const envRecord = this.convertEnvToRecord(serverEnv);
 
-    if (!baseUrl) {
-      throw new Error('No baseUrl found for LMStudio provider');
-    }
-
-    const isDocker = process?.env?.RUNNING_IN_DOCKER === 'true' || serverEnv?.RUNNING_IN_DOCKER === 'true';
-
-    if (typeof window === 'undefined') {
-      baseUrl = isDocker ? baseUrl.replace('localhost', 'host.docker.internal') : baseUrl;
-      baseUrl = isDocker ? baseUrl.replace('127.0.0.1', 'host.docker.internal') : baseUrl;
-    }
+    const baseUrl = this._resolveBaseUrl(apiKeys, providerSettings?.[this.name], envRecord);
 
     logger.debug('LMStudio Base Url used: ', baseUrl);
 


### PR DESCRIPTION
## Summary
- Eliminates duplicated Docker URL rewriting code (was copy-pasted 4 times across Ollama/LMStudio)
- Adds error handling and 5-second timeouts to all local provider model fetches
- Fixes Ollama provider mutating internal SDK state by using `createOllama()` properly
- Fixes LLMManager singleton ignoring env updates on subsequent Cloudflare Worker requests
- Adds connection status indicators (green/red dots) for local providers in the model selector
- Shows helpful "is X running?" messages when a local provider has no models

## Issues Fixed
1. **Duplicated code**: Docker URL rewriting was identical in 4 places — extracted to `BaseProvider.resolveDockerUrl()`
2. **No error handling**: Ollama/LMStudio `getDynamicModels` had zero try/catch — a crashed server would throw unhandled `TypeError: fetch failed`
3. **No timeouts**: One slow/hung local provider blocked all providers via `Promise.all` — added 5s `AbortSignal.timeout`
4. **Fragile SDK usage**: Ollama mutated `ollamaInstance.config.baseURL` via type cast — replaced with `createOllama({ baseURL })` 
5. **Stale env in singleton**: `LLMManager.getInstance(env)` ignored `env` after first call — now updates on each call
6. **Cache key too broad**: Serialized entire `serverEnv` into cache key — narrowed to only provider-relevant keys
7. **`as any` casts**: LMStudio/OpenAILike used `serverEnv as any` — replaced with shared `convertEnvToRecord()`
8. **No connection feedback**: Users had no idea if local providers were running — added status dots and helpful empty-state messages

## Files Changed
- `app/lib/modules/llm/base-provider.ts` — Added `resolveDockerUrl()`, `convertEnvToRecord()`, `createTimeoutSignal()`, narrowed cache key
- `app/lib/modules/llm/providers/ollama.ts` — Rewrote with shared helpers, proper `createOllama()`, error handling
- `app/lib/modules/llm/providers/lmstudio.ts` — Rewrote with shared helpers, error handling
- `app/lib/modules/llm/providers/openai-like.ts` — Added timeout, replaced `as any`, used logger
- `app/lib/modules/llm/manager.ts` — Fixed singleton env update, fixed typo
- `app/components/chat/ModelSelector.tsx` — Added local provider status dots and helpful empty states

## Test plan
- [ ] Select Ollama provider with Ollama running — green dot, models listed
- [ ] Select Ollama provider with Ollama stopped — red dot, "is Ollama running?" message
- [ ] Select LMStudio provider with LM Studio stopped — red dot, helpful message
- [ ] Verify model loading doesn't hang when one local provider is unreachable (5s timeout)
- [ ] Verify cloud providers (OpenAI, Anthropic, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)