### PR TITLE
feat: file lock button

### DIFF
--- a/app/components/ui/PanelHeaderButton.tsx
+++ b/app/components/ui/PanelHeaderButton.tsx
@@ -5,12 +5,13 @@ interface PanelHeaderButtonProps {
   className?: string;
   disabledClassName?: string;
   disabled?: boolean;
+  title?: string;
   children: string | JSX.Element | Array<JSX.Element | string>;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 export const PanelHeaderButton = memo(
-  ({ className, disabledClassName, disabled = false, children, onClick }: PanelHeaderButtonProps) => {
+  ({ className, disabledClassName, disabled = false, title, children, onClick }: PanelHeaderButtonProps) => {
     return (
       <button
         className={classNames(
@@ -21,6 +22,7 @@ export const PanelHeaderButton = memo(
           className,
         )}
         disabled={disabled}
+        title={title}
         onClick={(event) => {
           if (disabled) {
             return;


### PR DESCRIPTION
## Summary
- add a file lock/unlock button in the editor header
- provide tooltip titles for lock state and disable when locked by folder
- expose `title` on `PanelHeaderButton` for accessible tooltips

## Testing
- pnpm run typecheck
- pnpm run lint
- e2e: Playwright smoke (seed a file via workbench store, toggle Lock/Unlock button)
