### PR TITLE
feat: auto prompt optimization

### DIFF
--- a/app/components/@settings/tabs/features/FeaturesTab.tsx
+++ b/app/components/@settings/tabs/features/FeaturesTab.tsx
@@ -111,12 +111,14 @@ export default function FeaturesTab() {
     isLatestBranch,
     contextOptimizationEnabled,
     eventLogs,
+    autoPromptOptimization,
     setAutoSelectTemplate,
     enableLatestBranch,
     enableContextOptimization,
     setEventLogs,
     setPromptId,
     promptId,
+    setAutoPromptOptimization,
   } = useSettings();
 
   // Enable features by default on first load
@@ -140,6 +142,10 @@ export default function FeaturesTab() {
 
     if (eventLogs === undefined) {
       setEventLogs(true); // Default: ON - Enable event logging
+    }
+
+    if (autoPromptOptimization === undefined) {
+      setAutoPromptOptimization(true); // Default: ON - Optimize prompts for smaller models
     }
   }, []); // Only run once on component mount
 
@@ -169,12 +175,17 @@ export default function FeaturesTab() {
           toast.success(`Event logging ${enabled ? 'enabled' : 'disabled'}`);
           break;
         }
+        case 'autoPromptOptimization': {
+          setAutoPromptOptimization(enabled);
+          toast.success(`Auto prompt optimization ${enabled ? 'enabled' : 'disabled'}`);
+          break;
+        }
 
         default:
           break;
       }
     },
-    [enableLatestBranch, setAutoSelectTemplate, enableContextOptimization, setEventLogs],
+    [enableLatestBranch, setAutoSelectTemplate, enableContextOptimization, setEventLogs, setAutoPromptOptimization],
   );
 
   const features = {
@@ -210,6 +221,14 @@ export default function FeaturesTab() {
         icon: 'i-ph:list-bullets',
         enabled: eventLogs,
         tooltip: 'Enabled by default to record detailed logs of system events and user actions',
+      },
+      {
+        id: 'autoPromptOptimization',
+        title: 'Auto Prompt Optimization',
+        description: 'Use optimized prompts for smaller models automatically',
+        icon: 'i-ph:magic-wand',
+        enabled: autoPromptOptimization,
+        tooltip: 'Enabled by default to keep prompts concise for smaller context windows',
       },
     ],
     beta: [],

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -100,7 +100,8 @@ export const ChatImpl = memo(
       (project) => project.id === supabaseConn.selectedProjectId,
     );
     const supabaseAlert = useStore(workbenchStore.supabaseAlert);
-    const { activeProviders, promptId, autoSelectTemplate, contextOptimizationEnabled } = useSettings();
+    const { activeProviders, promptId, autoSelectTemplate, contextOptimizationEnabled, autoPromptOptimization } =
+      useSettings();
     const [llmErrorAlert, setLlmErrorAlert] = useState<LlmErrorAlertType | undefined>(undefined);
     const [model, setModel] = useState(() => {
       const savedModel = Cookies.get('selectedModel');
@@ -138,6 +139,7 @@ export const ChatImpl = memo(
         files,
         promptId,
         contextOptimization: contextOptimizationEnabled,
+        autoPromptOptimization,
         chatMode,
         designScheme,
         supabase: {

--- a/app/lib/hooks/useSettings.ts
+++ b/app/lib/hooks/useSettings.ts
@@ -7,6 +7,7 @@ import {
   latestBranchStore,
   autoSelectStarterTemplate,
   enableContextOptimizationStore,
+  autoPromptOptimizationStore,
   tabConfigurationStore,
   resetTabConfiguration as resetTabConfig,
   updateProviderSettings as updateProviderSettingsStore,
@@ -15,6 +16,7 @@ import {
   updateContextOptimization,
   updateEventLogs,
   updatePromptId,
+  updateAutoPromptOptimization,
 } from '~/lib/stores/settings';
 import { useCallback, useEffect, useState } from 'react';
 import Cookies from 'js-cookie';
@@ -58,6 +60,8 @@ export interface UseSettingsReturn {
   setAutoSelectTemplate: (enabled: boolean) => void;
   contextOptimizationEnabled: boolean;
   enableContextOptimization: (enabled: boolean) => void;
+  autoPromptOptimization: boolean;
+  setAutoPromptOptimization: (enabled: boolean) => void;
 
   // Tab configuration
   tabConfiguration: TabWindowConfig;
@@ -78,6 +82,7 @@ export function useSettings(): UseSettingsReturn {
   const autoSelectTemplate = useStore(autoSelectStarterTemplate);
   const [activeProviders, setActiveProviders] = useState<ProviderInfo[]>([]);
   const contextOptimizationEnabled = useStore(enableContextOptimizationStore);
+  const autoPromptOptimization = useStore(autoPromptOptimizationStore);
   const tabConfiguration = useStore(tabConfigurationStore);
   const [settings, setSettings] = useState<Settings>(() => {
     const storedSettings = getLocalStorage('settings');
@@ -143,6 +148,11 @@ export function useSettings(): UseSettingsReturn {
     logStore.logSystem(`Context optimization ${enabled ? 'enabled' : 'disabled'}`);
   }, []);
 
+  const setAutoPromptOptimization = useCallback((enabled: boolean) => {
+    updateAutoPromptOptimization(enabled);
+    logStore.logSystem(`Auto prompt optimization ${enabled ? 'enabled' : 'disabled'}`);
+  }, []);
+
   const setTheme = useCallback(
     (theme: Settings['theme']) => {
       saveSettings({ theme });
@@ -197,6 +207,8 @@ export function useSettings(): UseSettingsReturn {
     setAutoSelectTemplate,
     contextOptimizationEnabled,
     enableContextOptimization,
+    autoPromptOptimization,
+    setAutoPromptOptimization,
     setTheme,
     setLanguage,
     setNotifications,

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -258,6 +258,7 @@ const SETTINGS_KEYS = {
   EVENT_LOGS: 'isEventLogsEnabled',
   PROMPT_ID: 'promptId',
   DEVELOPER_MODE: 'isDeveloperMode',
+  AUTO_PROMPT_OPTIMIZATION: 'autoPromptOptimization',
 } as const;
 
 // Initialize settings from localStorage or defaults
@@ -287,6 +288,7 @@ const getInitialSettings = () => {
     eventLogs: getStoredBoolean(SETTINGS_KEYS.EVENT_LOGS, true),
     promptId: isBrowser ? localStorage.getItem(SETTINGS_KEYS.PROMPT_ID) || 'default' : 'default',
     developerMode: getStoredBoolean(SETTINGS_KEYS.DEVELOPER_MODE, false),
+    autoPromptOptimization: getStoredBoolean(SETTINGS_KEYS.AUTO_PROMPT_OPTIMIZATION, true),
   };
 };
 
@@ -298,6 +300,7 @@ export const autoSelectStarterTemplate = atom<boolean>(initialSettings.autoSelec
 export const enableContextOptimizationStore = atom<boolean>(initialSettings.contextOptimization);
 export const isEventLogsEnabled = atom<boolean>(initialSettings.eventLogs);
 export const promptStore = atom<string>(initialSettings.promptId);
+export const autoPromptOptimizationStore = atom<boolean>(initialSettings.autoPromptOptimization);
 
 // Helper functions to update settings with persistence
 export const updateLatestBranch = (enabled: boolean) => {
@@ -323,6 +326,11 @@ export const updateEventLogs = (enabled: boolean) => {
 export const updatePromptId = (id: string) => {
   promptStore.set(id);
   localStorage.setItem(SETTINGS_KEYS.PROMPT_ID, id);
+};
+
+export const updateAutoPromptOptimization = (enabled: boolean) => {
+  autoPromptOptimizationStore.set(enabled);
+  localStorage.setItem(SETTINGS_KEYS.AUTO_PROMPT_OPTIMIZATION, JSON.stringify(enabled));
 };
 
 // Initialize tab configuration from localStorage or defaults

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -48,24 +48,34 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
     },
   });
 
-  const { messages, files, promptId, contextOptimization, supabase, chatMode, designScheme, maxLLMSteps } =
-    await request.json<{
-      messages: Messages;
-      files: any;
-      promptId?: string;
-      contextOptimization: boolean;
-      chatMode: 'discuss' | 'build';
-      designScheme?: DesignScheme;
-      supabase?: {
-        isConnected: boolean;
-        hasSelectedProject: boolean;
-        credentials?: {
-          anonKey?: string;
-          supabaseUrl?: string;
-        };
+  const {
+    messages,
+    files,
+    promptId,
+    contextOptimization,
+    supabase,
+    chatMode,
+    designScheme,
+    maxLLMSteps,
+    autoPromptOptimization,
+  } = await request.json<{
+    messages: Messages;
+    files: any;
+    promptId?: string;
+    contextOptimization: boolean;
+    chatMode: 'discuss' | 'build';
+    designScheme?: DesignScheme;
+    autoPromptOptimization?: boolean;
+    supabase?: {
+      isConnected: boolean;
+      hasSelectedProject: boolean;
+      credentials?: {
+        anonKey?: string;
+        supabaseUrl?: string;
       };
-      maxLLMSteps: number;
-    }>();
+    };
+    maxLLMSteps: number;
+  }>();
 
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
@@ -278,6 +288,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               contextFiles: filteredFiles,
               chatMode,
               designScheme,
+              autoPromptOptimization,
               summary,
               messageSliceId,
             });
@@ -319,6 +330,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
           contextFiles: filteredFiles,
           chatMode,
           designScheme,
+          autoPromptOptimization,
           summary,
           messageSliceId,
         });


### PR DESCRIPTION
## Summary
- add Auto Prompt Optimization toggle in settings (default on)
- persist the setting and include it in `/api/chat` payloads
- switch to the optimized prompt template for smaller‑context models automatically

## Testing
- pnpm run typecheck
- pnpm run lint
- e2e: Playwright smoke (send chat, assert `autoPromptOptimization: true` in request)
