### PR TITLE
feat: framework lock

### DIFF
--- a/app/components/@settings/tabs/features/FeaturesTab.tsx
+++ b/app/components/@settings/tabs/features/FeaturesTab.tsx
@@ -111,10 +111,12 @@ export default function FeaturesTab() {
     isLatestBranch,
     contextOptimizationEnabled,
     eventLogs,
+    frameworkLock,
     setAutoSelectTemplate,
     enableLatestBranch,
     enableContextOptimization,
     setEventLogs,
+    setFrameworkLock,
     setPromptId,
     promptId,
   } = useSettings();
@@ -169,12 +171,17 @@ export default function FeaturesTab() {
           toast.success(`Event logging ${enabled ? 'enabled' : 'disabled'}`);
           break;
         }
+        case 'frameworkLock': {
+          setFrameworkLock(enabled);
+          toast.success(`Framework lock ${enabled ? 'enabled' : 'disabled'}`);
+          break;
+        }
 
         default:
           break;
       }
     },
-    [enableLatestBranch, setAutoSelectTemplate, enableContextOptimization, setEventLogs],
+    [enableLatestBranch, setAutoSelectTemplate, enableContextOptimization, setEventLogs, setFrameworkLock],
   );
 
   const features = {
@@ -212,7 +219,17 @@ export default function FeaturesTab() {
         tooltip: 'Enabled by default to record detailed logs of system events and user actions',
       },
     ],
-    beta: [],
+    beta: [
+      {
+        id: 'frameworkLock',
+        title: 'Framework Lock',
+        description: 'Keep the assistant aligned with the detected stack unless you ask to change it',
+        icon: 'i-ph:lock-closed',
+        enabled: frameworkLock,
+        beta: true,
+        tooltip: 'Uses package.json to detect the framework and keeps suggestions within that stack',
+      },
+    ],
   };
 
   return (

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -65,6 +65,7 @@ export async function streamText(props: {
   messageSliceId?: number;
   chatMode?: 'discuss' | 'build';
   designScheme?: DesignScheme;
+  frameworkHint?: string;
 }) {
   const {
     messages,
@@ -79,6 +80,7 @@ export async function streamText(props: {
     summary,
     chatMode,
     designScheme,
+    frameworkHint,
   } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
@@ -217,6 +219,16 @@ export async function streamText(props: {
     `;
   } else {
     console.log('No locked files found from any source for prompt.');
+  }
+
+  if (frameworkHint) {
+    systemPrompt = `${systemPrompt}
+
+    PROJECT FRAMEWORK (DETECTED):
+    ${sanitizeText(frameworkHint)}
+    IMPORTANT: Stay within this framework unless the user explicitly asks to change stacks.
+    ---
+    `;
   }
 
   logger.info(`Sending llm call to ${provider.name} with model ${modelDetails.name}`);

--- a/app/lib/hooks/useSettings.ts
+++ b/app/lib/hooks/useSettings.ts
@@ -7,6 +7,7 @@ import {
   latestBranchStore,
   autoSelectStarterTemplate,
   enableContextOptimizationStore,
+  frameworkLockStore,
   tabConfigurationStore,
   resetTabConfiguration as resetTabConfig,
   updateProviderSettings as updateProviderSettingsStore,
@@ -15,6 +16,7 @@ import {
   updateContextOptimization,
   updateEventLogs,
   updatePromptId,
+  updateFrameworkLock,
 } from '~/lib/stores/settings';
 import { useCallback, useEffect, useState } from 'react';
 import Cookies from 'js-cookie';
@@ -58,6 +60,8 @@ export interface UseSettingsReturn {
   setAutoSelectTemplate: (enabled: boolean) => void;
   contextOptimizationEnabled: boolean;
   enableContextOptimization: (enabled: boolean) => void;
+  frameworkLock: boolean;
+  setFrameworkLock: (enabled: boolean) => void;
 
   // Tab configuration
   tabConfiguration: TabWindowConfig;
@@ -78,6 +82,7 @@ export function useSettings(): UseSettingsReturn {
   const autoSelectTemplate = useStore(autoSelectStarterTemplate);
   const [activeProviders, setActiveProviders] = useState<ProviderInfo[]>([]);
   const contextOptimizationEnabled = useStore(enableContextOptimizationStore);
+  const frameworkLock = useStore(frameworkLockStore);
   const tabConfiguration = useStore(tabConfigurationStore);
   const [settings, setSettings] = useState<Settings>(() => {
     const storedSettings = getLocalStorage('settings');
@@ -143,6 +148,11 @@ export function useSettings(): UseSettingsReturn {
     logStore.logSystem(`Context optimization ${enabled ? 'enabled' : 'disabled'}`);
   }, []);
 
+  const setFrameworkLock = useCallback((enabled: boolean) => {
+    updateFrameworkLock(enabled);
+    logStore.logSystem(`Framework lock ${enabled ? 'enabled' : 'disabled'}`);
+  }, []);
+
   const setTheme = useCallback(
     (theme: Settings['theme']) => {
       saveSettings({ theme });
@@ -197,6 +207,8 @@ export function useSettings(): UseSettingsReturn {
     setAutoSelectTemplate,
     contextOptimizationEnabled,
     enableContextOptimization,
+    frameworkLock,
+    setFrameworkLock,
     setTheme,
     setLanguage,
     setNotifications,

--- a/app/lib/stores/settings.ts
+++ b/app/lib/stores/settings.ts
@@ -258,6 +258,7 @@ const SETTINGS_KEYS = {
   EVENT_LOGS: 'isEventLogsEnabled',
   PROMPT_ID: 'promptId',
   DEVELOPER_MODE: 'isDeveloperMode',
+  FRAMEWORK_LOCK: 'frameworkLock',
 } as const;
 
 // Initialize settings from localStorage or defaults
@@ -287,6 +288,7 @@ const getInitialSettings = () => {
     eventLogs: getStoredBoolean(SETTINGS_KEYS.EVENT_LOGS, true),
     promptId: isBrowser ? localStorage.getItem(SETTINGS_KEYS.PROMPT_ID) || 'default' : 'default',
     developerMode: getStoredBoolean(SETTINGS_KEYS.DEVELOPER_MODE, false),
+    frameworkLock: getStoredBoolean(SETTINGS_KEYS.FRAMEWORK_LOCK, false),
   };
 };
 
@@ -298,6 +300,7 @@ export const autoSelectStarterTemplate = atom<boolean>(initialSettings.autoSelec
 export const enableContextOptimizationStore = atom<boolean>(initialSettings.contextOptimization);
 export const isEventLogsEnabled = atom<boolean>(initialSettings.eventLogs);
 export const promptStore = atom<string>(initialSettings.promptId);
+export const frameworkLockStore = atom<boolean>(initialSettings.frameworkLock);
 
 // Helper functions to update settings with persistence
 export const updateLatestBranch = (enabled: boolean) => {
@@ -323,6 +326,11 @@ export const updateEventLogs = (enabled: boolean) => {
 export const updatePromptId = (id: string) => {
   promptStore.set(id);
   localStorage.setItem(SETTINGS_KEYS.PROMPT_ID, id);
+};
+
+export const updateFrameworkLock = (enabled: boolean) => {
+  frameworkLockStore.set(enabled);
+  localStorage.setItem(SETTINGS_KEYS.FRAMEWORK_LOCK, JSON.stringify(enabled));
 };
 
 // Initialize tab configuration from localStorage or defaults

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -48,24 +48,34 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
     },
   });
 
-  const { messages, files, promptId, contextOptimization, supabase, chatMode, designScheme, maxLLMSteps } =
-    await request.json<{
-      messages: Messages;
-      files: any;
-      promptId?: string;
-      contextOptimization: boolean;
-      chatMode: 'discuss' | 'build';
-      designScheme?: DesignScheme;
-      supabase?: {
-        isConnected: boolean;
-        hasSelectedProject: boolean;
-        credentials?: {
-          anonKey?: string;
-          supabaseUrl?: string;
-        };
+  const {
+    messages,
+    files,
+    promptId,
+    contextOptimization,
+    supabase,
+    chatMode,
+    designScheme,
+    maxLLMSteps,
+    frameworkHint,
+  } = await request.json<{
+    messages: Messages;
+    files: any;
+    promptId?: string;
+    contextOptimization: boolean;
+    chatMode: 'discuss' | 'build';
+    designScheme?: DesignScheme;
+    frameworkHint?: string;
+    supabase?: {
+      isConnected: boolean;
+      hasSelectedProject: boolean;
+      credentials?: {
+        anonKey?: string;
+        supabaseUrl?: string;
       };
-      maxLLMSteps: number;
-    }>();
+    };
+    maxLLMSteps: number;
+  }>();
 
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
@@ -278,6 +288,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               contextFiles: filteredFiles,
               chatMode,
               designScheme,
+              frameworkHint,
               summary,
               messageSliceId,
             });
@@ -319,6 +330,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
           contextFiles: filteredFiles,
           chatMode,
           designScheme,
+          frameworkHint,
           summary,
           messageSliceId,
         });

--- a/app/utils/framework.ts
+++ b/app/utils/framework.ts
@@ -1,0 +1,116 @@
+import type { FileMap } from '~/lib/stores/files';
+import { WORK_DIR } from '~/utils/constants';
+
+const PACKAGE_JSON_PATH = `${WORK_DIR}/package.json`;
+const FALLBACK_PACKAGE_JSON_PATH = 'package.json';
+
+const getPackageJsonContent = (files?: FileMap): string | undefined => {
+  if (!files) {
+    return undefined;
+  }
+
+  const direct = files[PACKAGE_JSON_PATH] || files[FALLBACK_PACKAGE_JSON_PATH];
+
+  if (!direct || direct.type !== 'file') {
+    return undefined;
+  }
+
+  if (typeof direct.content !== 'string') {
+    return undefined;
+  }
+
+  return direct.content;
+};
+
+export const detectFrameworkFromFiles = (files?: FileMap): string | null => {
+  const content = getPackageJsonContent(files);
+
+  if (!content) {
+    return null;
+  }
+
+  try {
+    const pkg = JSON.parse(content) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+
+    const deps = {
+      ...(pkg.dependencies || {}),
+      ...(pkg.devDependencies || {}),
+      ...(pkg.peerDependencies || {}),
+    };
+
+    const has = (name: string) => Boolean(deps[name]);
+    const hasPrefix = (prefix: string) => Object.keys(deps).some((key) => key.startsWith(prefix));
+
+    if (has('expo')) {
+      return 'Expo (React Native)';
+    }
+
+    if (has('react-native')) {
+      return 'React Native';
+    }
+
+    if (has('next')) {
+      return 'Next.js';
+    }
+
+    if (hasPrefix('@remix-run/')) {
+      return 'Remix';
+    }
+
+    if (has('astro')) {
+      return 'Astro';
+    }
+
+    if (has('@sveltejs/kit')) {
+      return 'SvelteKit';
+    }
+
+    if (has('svelte')) {
+      return 'Svelte';
+    }
+
+    if (has('nuxt')) {
+      return 'Nuxt';
+    }
+
+    if (has('vue')) {
+      return 'Vue';
+    }
+
+    if (has('@angular/core')) {
+      return 'Angular';
+    }
+
+    if (has('@builder.io/qwik')) {
+      return 'Qwik';
+    }
+
+    if (has('solid-js')) {
+      return 'SolidJS';
+    }
+
+    if (has('vite') && has('react')) {
+      return 'React + Vite';
+    }
+
+    if (has('react')) {
+      return 'React';
+    }
+
+    if (has('preact')) {
+      return 'Preact';
+    }
+
+    if (has('vite')) {
+      return 'Vite';
+    }
+  } catch (error) {
+    console.warn('Failed to parse package.json for framework detection', error);
+  }
+
+  return null;
+};


### PR DESCRIPTION
  ## summary
  - add a framework lock toggle in Settings → Features
  - detect the framework from package.json and include a framework hint in chat requests
  - inject the hint into the system prompt to keep changes within the current stack

  ## why
  - helps prevent accidental framework switches and keeps suggestions aligned with the project