### PR TITLE
fix: move wrangler to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "use-debounce": "^10.0.4",
     "vite-plugin-node-polyfills": "^0.22.0",
     "zod": "^3.24.1",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "wrangler": "^4.44.0"
   },
   "devDependencies": {
     "@blitz/eslint-plugin": "0.1.0",
@@ -205,8 +206,7 @@
     "vite-plugin-copy": "^0.1.6",
     "vite-plugin-optimize-css-modules": "^1.1.0",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^2.1.7",
-    "wrangler": "^4.44.0"
+    "vitest": "^2.1.7"
   },
   "resolutions": {
     "@typescript-eslint/utils": "^8.0.0-alpha.30"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       vite-plugin-node-polyfills:
         specifier: ^0.22.0
         version: 0.22.0(rollup@4.45.1)(vite@5.4.19(@types/node@24.1.0)(sass-embedded@1.89.2))
+      wrangler:
+        specifier: ^4.44.0
+        version: 4.44.0(@cloudflare/workers-types@4.20251014.0)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -486,9 +489,6 @@ importers:
       vitest:
         specifier: ^2.1.7
         version: 2.1.9(@types/node@24.1.0)(jsdom@26.1.0)(sass-embedded@1.89.2)
-      wrangler:
-        specifier: ^4.44.0
-        version: 4.44.0(@cloudflare/workers-types@4.20251014.0)
 
 packages:
 
@@ -14229,7 +14229,7 @@ snapshots:
   importx@0.4.4:
     dependencies:
       bundle-require: 5.1.0(esbuild@0.23.1)
-      debug: 4.4.1
+      debug: 4.4.3
       esbuild: 0.23.1
       jiti: 2.0.0-beta.3
       jiti-v1: jiti@1.21.7
@@ -15285,7 +15285,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0


### PR DESCRIPTION
  Fixes #2080

  ## Problem
  The production Docker image prunes devDependencies (`pnpm prune --prod`), but the runtime startup scripts call `wrangler pages dev`. When `wrangler` is only in devDependencies it
  gets removed and the container fails to start.

  ## Solution
  Move `wrangler` to `dependencies` so it remains available after production pruning.

  ## Testing
  - pnpm test
  - Simulated Docker prune: `pnpm prune --prod --ignore-scripts` and verified `node_modules/.bin/wrangler --version` works