### PR TITLE
Add User-Agent header for Anthropic API calls

### DIFF
--- a/app/lib/modules/llm/providers/anthropic.spec.ts
+++ b/app/lib/modules/llm/providers/anthropic.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn().mockReturnValue(vi.fn().mockReturnValue({ id: 'mock-model' })),
+}));
+
+vi.mock('~/lib/modules/llm/manager', () => ({
+  LLMManager: {
+    getInstance: vi.fn().mockReturnValue({ env: {} }),
+  },
+}));
+
+import AnthropicProvider from './anthropic';
+import { createAnthropic } from '@ai-sdk/anthropic';
+
+describe('AnthropicProvider', () => {
+  it('passes User-Agent header when creating Anthropic client', () => {
+    const provider = new AnthropicProvider();
+    provider.getModelInstance({
+      model: 'claude-3-5-sonnet-20241022',
+      serverEnv: {} as any,
+      apiKeys: { ANTHROPIC_API_KEY: 'test-key' },
+      providerSettings: {},
+    });
+
+    expect(createAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': expect.stringMatching(/^bolt\.diy\//),
+        }),
+      }),
+    );
+  });
+});

--- a/app/lib/modules/llm/providers/anthropic.ts
+++ b/app/lib/modules/llm/providers/anthropic.ts
@@ -127,7 +127,10 @@ export default class AnthropicProvider extends BaseProvider {
     });
     const anthropic = createAnthropic({
       apiKey,
-      headers: { 'anthropic-beta': 'output-128k-2025-02-19' },
+      headers: {
+        'anthropic-beta': 'output-128k-2025-02-19',
+        'User-Agent': 'bolt.diy/1.0.0',
+      },
     });
 
     return anthropic(model);


### PR DESCRIPTION
 Passes User-Agent: bolt.diy/1.0.0 to the Anthropic SDK