### PR TITLE
feat: Add ModelsLab provider for uncensored AI models

### DIFF
--- a/app/lib/modules/llm/providers/modelslab.ts
+++ b/app/lib/modules/llm/providers/modelslab.ts
@@ -1,0 +1,111 @@
+import { BaseProvider, getOpenAILikeModel } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+
+export default class ModelsLabProvider extends BaseProvider {
+  name = 'ModelsLab';
+  getApiKeyLink = 'https://modelslab.com/dashboard/settings';
+  labelForGetApiKey = 'Get ModelsLab API Key';
+  icon = 'i-ph:cloud-lightning';
+
+  config = {
+    baseUrlKey: 'MODELSLAB_API_BASE_URL',
+    apiTokenKey: 'MODELSLAB_API_KEY',
+    baseUrl: 'https://modelslab.com/api/uncensored-chat/v1',
+  };
+
+  staticModels: ModelInfo[] = [
+    {
+      name: 'meta-llama/llama-3.1-8b-instruct-uncensored',
+      label: 'Llama 3.1 8B Uncensored (ModelsLab)',
+      provider: 'ModelsLab',
+      maxTokenAllowed: 32768,
+      maxCompletionTokens: 4096,
+    },
+    {
+      name: 'meta-llama/llama-3.1-70b-instruct-uncensored',
+      label: 'Llama 3.1 70B Uncensored (ModelsLab)',
+      provider: 'ModelsLab',
+      maxTokenAllowed: 32768,
+      maxCompletionTokens: 4096,
+    },
+  ];
+
+  async getDynamicModels(
+    apiKeys?: Record<string, string>,
+    settings?: IProviderSetting,
+    serverEnv: Record<string, string> = {},
+  ): Promise<ModelInfo[]> {
+    const { baseUrl, apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: settings,
+      serverEnv,
+      defaultBaseUrlKey: 'MODELSLAB_API_BASE_URL',
+      defaultApiTokenKey: 'MODELSLAB_API_KEY',
+    });
+
+    const resolvedBaseUrl = baseUrl || 'https://modelslab.com/api/uncensored-chat/v1';
+
+    if (!apiKey) {
+      return [];
+    }
+
+    try {
+      const response = await fetch(`${resolvedBaseUrl}/models`, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        signal: this.createTimeoutSignal(),
+      });
+
+      if (!response.ok) {
+        return [];
+      }
+
+      const res = (await response.json()) as any;
+      const models = Array.isArray(res?.data) ? res.data : Array.isArray(res) ? res : [];
+
+      return models
+        .filter((m: any) => m.id || m.name)
+        .map((m: any) => ({
+          name: m.id || m.name,
+          label: m.display_name || m.id || m.name,
+          provider: this.name,
+          maxTokenAllowed: m.context_length || 32768,
+          maxCompletionTokens: m.max_completion_tokens || 4096,
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    const { baseUrl, apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: this.convertEnvToRecord(serverEnv),
+      defaultBaseUrlKey: 'MODELSLAB_API_BASE_URL',
+      defaultApiTokenKey: 'MODELSLAB_API_KEY',
+    });
+
+    if (!apiKey) {
+      throw new Error(`Missing API key for ${this.name} provider. Set MODELSLAB_API_KEY in your environment.`);
+    }
+
+    const resolvedBaseUrl = this.resolveDockerUrl(
+      baseUrl || 'https://modelslab.com/api/uncensored-chat/v1',
+      this.convertEnvToRecord(serverEnv),
+    );
+
+    return getOpenAILikeModel(resolvedBaseUrl, apiKey, model);
+  }
+}


### PR DESCRIPTION
# feat: Add ModelsLab provider for uncensored AI models

## Summary

Adds **ModelsLab** as a new LLM provider to bolt.diy, following the existing provider pattern exactly.

ModelsLab provides access to powerful uncensored AI models (Llama 3.1 8B/70B Uncensored) via an OpenAI-compatible API — making it a seamless drop-in addition.

## What's Added

### New file: `app/lib/modules/llm/providers/modelslab.ts`
- Extends `BaseProvider` following the same pattern as `TogetherProvider`, `GroqProvider`, etc.
- Uses `getOpenAILikeModel()` — ModelsLab's API is fully OpenAI-compatible
- Static models: Llama 3.1 8B Uncensored, Llama 3.1 70B Uncensored
- Dynamic model listing via `/models` endpoint
- Docker URL resolution support

### Modified: `app/lib/modules/llm/registry.ts`
- Added `ModelsLabProvider` import and export (2 lines)

## Setup

Users add to their `.env.local`:
```
MODELSLAB_API_KEY=your_key_here
# Optional custom base URL:
# MODELSLAB_API_BASE_URL=https://modelslab.com/api/uncensored-chat/v1
```

Then select **ModelsLab** from the provider dropdown and choose a model.

Get an API key: https://modelslab.com/dashboard/settings

## Why ModelsLab?

- **Uncensored models**: Llama 3.1 Uncensored — useful for creative, research, and unrestricted coding tasks
- **Cost-effective**: Competitive pricing vs other providers
- **OpenAI-compatible**: Zero friction integration using existing `getOpenAILikeModel` helper
- **Aligns with bolt.diy's mission**: More provider choice = more freedom for users

## Testing

```bash
# Set env var
echo "MODELSLAB_API_KEY=your_key" >> .env.local

# Run bolt.diy
pnpm run dev

# Select ModelsLab from provider dropdown
# Choose a Llama 3.1 Uncensored model
# Start building!
```

## Checklist

- [x] Follows existing provider pattern (`BaseProvider` extension)
- [x] Uses `getOpenAILikeModel` helper (no new dependencies)
- [x] Static models defined
- [x] Dynamic model fetching implemented
- [x] Docker URL resolution support
- [x] Registered in `registry.ts`
- [x] API key link provided for users
- [x] No breaking changes
- [x] Consistent code style with existing providers