### PR TITLE
feat: added kimi-coding provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,10 @@ HuggingFace_API_KEY=your_huggingface_api_key_here
 # Get your API key from: https://app.hyperbolic.xyz/settings
 HYPERBOLIC_API_KEY=your_hyperbolic_api_key_here
 
+# Kimi Coding (Kimi For Coding - specialized coding model)
+# Get your API key from: https://www.kimi.com/code/console
+KIMI_CODING_API_KEY=your_kimi_coding_api_key_here
+
 # OpenRouter (Meta routing for multiple providers)
 # Get your API key from: https://openrouter.ai/keys
 OPEN_ROUTER_API_KEY=your_openrouter_api_key_here

--- a/app/lib/modules/llm/providers/kimi-coding.ts
+++ b/app/lib/modules/llm/providers/kimi-coding.ts
@@ -1,0 +1,55 @@
+import { BaseProvider } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+
+export default class KimiCodingProvider extends BaseProvider {
+  name = 'KimiCoding';
+  getApiKeyLink = 'https://www.kimi.com/code/console';
+
+  config = {
+    apiTokenKey: 'KIMI_CODING_API_KEY',
+    baseUrl: 'https://api.kimi.com/coding/v1',
+  };
+
+  staticModels: ModelInfo[] = [
+    {
+      name: 'kimi-for-coding',
+      label: 'Kimi For Coding',
+      provider: 'KimiCoding',
+      maxTokenAllowed: 262144,
+    },
+  ];
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    const { apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: '',
+      defaultApiTokenKey: 'KIMI_CODING_API_KEY',
+    });
+
+    if (!apiKey) {
+      throw new Error(`Missing API key for ${this.name} provider`);
+    }
+
+    const openai = createOpenAI({
+      baseURL: 'https://api.kimi.com/coding/v1',
+      apiKey,
+      headers: {
+        'User-Agent': 'claude-code/1.0',
+      },
+    });
+
+    return openai(model);
+  }
+}

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -18,6 +18,7 @@ import XAIProvider from './providers/xai';
 import HyperbolicProvider from './providers/hyperbolic';
 import AmazonBedrockProvider from './providers/amazon-bedrock';
 import GithubProvider from './providers/github';
+import KimiCodingProvider from './providers/kimi-coding';
 import MoonshotProvider from './providers/moonshot';
 import ZaiProvider from './providers/z-ai';
 
@@ -31,6 +32,7 @@ export {
   GroqProvider,
   HuggingFaceProvider,
   HyperbolicProvider,
+  KimiCodingProvider,
   MistralProvider,
   MoonshotProvider,
   OllamaProvider,


### PR DESCRIPTION
Add support for Moonshot AI's Kimi Coding model to bolt.diy.

## Changes
- Added `kimi-coding.ts` provider file
- Registered provider in `registry.ts`
- Added `KIMI_CODING_API_KEY` to `.env.example`

## Provider Details
- **Name:** KimiCoding
- **Model:** kimi-for-coding
- **Max Tokens:** 262,144
- **API Endpoint:** https://api.kimi.com/coding/v1
- **API Key:** Get from https://www.kimi.com/code/console

## Usage
Set `KIMI_CODING_API_KEY` in your `.env.local` file or configure via the UI.
