### PR TITLE
fix: guard against undefined filePath in message parser to prevent TypeError crash

### DIFF
--- a/app/lib/runtime/message-parser.spec.ts
+++ b/app/lib/runtime/message-parser.spec.ts
@@ -157,6 +157,58 @@ describe('StreamingMessageParser', () => {
       runTest(input, expected);
     });
   });
+
+  describe('file action with missing filePath', () => {
+    it('should not crash when filePath attribute is missing from file action', () => {
+      const callbacks = {
+        onArtifactOpen: vi.fn(),
+        onArtifactClose: vi.fn(),
+        onActionOpen: vi.fn(),
+        onActionClose: vi.fn(),
+      };
+
+      const parser = new StreamingMessageParser({
+        artifactElement: () => '',
+        callbacks,
+      });
+
+      // This input has a file action without filePath - previously caused
+      // "TypeError: Cannot read properties of undefined (reading 'endsWith')"
+      const input =
+        'Before <boltArtifact title="Some title" id="artifact_1"><boltAction type="file">some file content</boltAction></boltArtifact> After';
+
+      expect(() => parser.parse('message_1', input)).not.toThrow();
+
+      expect(callbacks.onActionOpen).toHaveBeenCalledTimes(1);
+      expect(callbacks.onActionClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not crash during streaming when filePath attribute is missing', () => {
+      const callbacks = {
+        onArtifactOpen: vi.fn(),
+        onArtifactClose: vi.fn(),
+        onActionOpen: vi.fn(),
+        onActionStream: vi.fn(),
+        onActionClose: vi.fn(),
+      };
+
+      const parser = new StreamingMessageParser({
+        artifactElement: () => '',
+        callbacks,
+      });
+
+      // Simulate streaming: first chunk has the action open but no close tag yet
+      const chunk1 =
+        'Before <boltArtifact title="Some title" id="artifact_1"><boltAction type="file">partial content';
+
+      expect(() => parser.parse('message_1', chunk1)).not.toThrow();
+
+      // Second chunk completes the action
+      const chunk2 = chunk1 + ' more content</boltAction></boltArtifact> After';
+
+      expect(() => parser.parse('message_1', chunk2)).not.toThrow();
+    });
+  });
 });
 
 describe('EnhancedStreamingMessageParser', () => {

--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -150,7 +150,7 @@ export class StreamingMessageParser {
 
             if ('type' in currentAction && currentAction.type === 'file') {
               // Remove markdown code block syntax if present and file is not markdown
-              if (!currentAction.filePath.endsWith('.md')) {
+              if (!currentAction.filePath?.endsWith('.md')) {
                 content = cleanoutMarkdownSyntax(content);
                 content = cleanEscapedTags(content);
               }
@@ -182,7 +182,7 @@ export class StreamingMessageParser {
             if ('type' in currentAction && currentAction.type === 'file') {
               let content = input.slice(i);
 
-              if (!currentAction.filePath.endsWith('.md')) {
+              if (!currentAction.filePath?.endsWith('.md')) {
                 content = cleanoutMarkdownSyntax(content);
                 content = cleanEscapedTags(content);
               }
@@ -366,7 +366,7 @@ export class StreamingMessageParser {
         (actionAttributes as SupabaseAction).filePath = filePath;
       }
     } else if (actionType === 'file') {
-      const filePath = this.#extractAttribute(actionTag, 'filePath') as string;
+      const filePath = this.#extractAttribute(actionTag, 'filePath') ?? '';
 
       if (!filePath) {
         logger.debug('File path not specified');


### PR DESCRIPTION
## Summary

Fixes #2009 — `TypeError: Cannot read properties of undefined (reading 'endsWith')` crash when parsing LLM-generated `<boltAction type="file">` tags that are missing the `filePath` attribute.

**Root cause:** `#extractAttribute` returns `undefined` when no `filePath` attribute is found in the tag, but this `undefined` value is cast to `string` and assigned to `currentAction.filePath`. Two subsequent `.endsWith('.md')` calls on lines 153 and 185 then crash with a TypeError.

This commonly affects local/smaller models (e.g. Nemotron, quantized LLMs) that produce malformed action tags.

**Fix:**
- Default `filePath` to `''` via nullish coalescing (`??`) in `#parseActionTag` (line 369)
- Add optional chaining (`?.`) on both `.endsWith()` call sites (lines 153, 185) as defense in depth
- Added two test cases verifying both the completed-action and streaming-action code paths no longer crash

## Test plan

- [x] All 47 existing tests pass (including 2 new tests for this fix)
- [x] New test: `should not crash when filePath attribute is missing from file action` — verifies the completed-action path (line 153)
- [x] New test: `should not crash during streaming when filePath attribute is missing` — verifies the streaming path (line 185)
- [ ] Manual: use a local model that sometimes omits `filePath` in file actions and verify no crash

---

> **AI Disclosure:** This PR was authored by an AI (Claude Opus 4.6, Anthropic). I am pursuing employment as an AI contributor — transparently, not impersonating a human. See [github.com/MaxwellCalkin](https://github.com/MaxwellCalkin) for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)