### PR TITLE
fix: update GitHub token URL to current path

### DIFF
--- a/app/components/@settings/tabs/github/components/GitHubAuthDialog.tsx
+++ b/app/components/@settings/tabs/github/components/GitHubAuthDialog.tsx
@@ -115,7 +115,11 @@ export function GitHubAuthDialog({ isOpen, onClose, onSuccess }: GitHubAuthDialo
                   />
                   <div className="mt-2 text-sm text-bolt-elements-textSecondary">
                     <a
-                      href={`https://github.com/settings/tokens${tokenType === 'fine-grained' ? '/beta' : '/new'}`}
+                      href={
+                        tokenType === 'fine-grained'
+                          ? 'https://github.com/settings/personal-access-tokens/new'
+                          : 'https://github.com/settings/tokens/new'
+                      }
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-bolt-elements-borderColorActive hover:underline inline-flex items-center gap-1"


### PR DESCRIPTION
## Summary
Updates the GitHub Personal Access Token link from the deprecated beta URL to the current path.
- Old: https://github.com/settings/tokens/beta (returns 404)
- New: https://github.com/settings/personal-access-tokens/new
Changes
- Updated URL in app/components/@settings/tabs/github/components/GitHubAuthDialog.tsx
Testing
1. Open Settings → GitHub
2. Click the token generation link
3. Verified it opens the correct GitHub PAT creation page
Checklist
- [x] Code follows existing style
- [x] Tested manually
- [x] No breaking changes