### PR TITLE
Feat/prompt queue

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -28,6 +28,7 @@ import type { ProgressAnnotation } from '~/types/context';
 import { SupabaseChatAlert } from '~/components/chat/SupabaseAlert';
 import { expoUrlAtom } from '~/lib/stores/qrCodeStore';
 import { useStore } from '@nanostores/react';
+import { PromptQueuePanel } from './PromptQueuePanel';
 import { StickToBottom, useStickToBottomContext } from '~/lib/hooks';
 import { ChatBox } from './ChatBox';
 import type { DesignScheme } from '~/types/design-scheme';
@@ -469,6 +470,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   setSelectedElement={setSelectedElement}
                   onWebSearchResult={onWebSearchResult}
                 />
+                {chatStarted && <PromptQueuePanel isStreaming={isStreaming} />}
               </div>
             </StickToBottom>
             <div className="flex flex-col justify-center">

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -21,6 +21,7 @@ import { createSampler } from '~/utils/sampler';
 import { getTemplates, selectStarterTemplate } from '~/utils/selectStarterTemplate';
 import { logStore } from '~/lib/stores/logs';
 import { streamingState } from '~/lib/stores/streaming';
+import { promptQueueStore, advanceQueue, clearPendingPrompt, stopQueue } from '~/lib/stores/promptQueue';
 import { filesToArtifacts } from '~/utils/fileUtils';
 import { supabaseConnection } from '~/lib/stores/supabase';
 import { defaultDesignScheme, type DesignScheme } from '~/types/design-scheme';
@@ -154,6 +155,7 @@ export const ChatImpl = memo(
       onError: (e) => {
         setFakeLoading(false);
         handleError(e, 'chat');
+        stopQueue();
       },
       onFinish: (message, response) => {
         const usage = response.usage;
@@ -172,6 +174,16 @@ export const ChatImpl = memo(
         }
 
         logger.debug('Finished streaming');
+
+        /* Advance the prompt queue if one is running */
+        const nextPrompt = advanceQueue();
+
+        if (nextPrompt) {
+          /* Small delay so the UI can settle before the next message fires */
+          setTimeout(() => {
+            promptQueueStore.setKey('pendingPrompt', nextPrompt);
+          }, 800);
+        }
       },
       initialMessages,
       initialInput: Cookies.get(PROMPT_COOKIE_KEY) || '',
@@ -217,6 +229,20 @@ export const ChatImpl = memo(
         setInput(autorun);
       }
     }, []);
+
+    /* Fire the next queued prompt whenever the store signals one is ready */
+    useEffect(() => {
+      const unsubscribe = promptQueueStore.subscribe((state) => {
+        if (state.pendingPrompt) {
+          clearPendingPrompt();
+
+          const messageText = `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${state.pendingPrompt}`;
+          append({ role: 'user', content: messageText });
+        }
+      });
+
+      return unsubscribe;
+    }, [append, model, provider]);
 
     useEffect(() => {
       processSampledMessages({

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -200,6 +200,24 @@ export const ChatImpl = memo(
       chatStore.setKey('started', initialMessages.length > 0);
     }, []);
 
+    /*
+     * Pre-fill the textarea with the follow-up prompt set by ImportZipButton before the
+     * full-page navigation. Using setInput instead of append so the user confirms with
+     * one Enter keystroke — avoids model-state race conditions on chat initialisation.
+     */
+    useEffect(() => {
+      if (initialMessages.length === 0) {
+        return;
+      }
+
+      const autorun = localStorage.getItem('bolt_zip_autorun');
+
+      if (autorun) {
+        localStorage.removeItem('bolt_zip_autorun');
+        setInput(autorun);
+      }
+    }, []);
+
     useEffect(() => {
       processSampledMessages({
         messages,

--- a/app/components/chat/ImportZipButton.tsx
+++ b/app/components/chat/ImportZipButton.tsx
@@ -42,7 +42,16 @@ export const ImportZipButton: React.FC<ImportZipButtonProps> = ({ className, imp
        * importChat does a full window.location.href redirect, so append()
        * would be gone by the time it resolves.
        */
-      if (result.hasPackageJson) {
+      if (result.hasExpoConfig) {
+        /*
+         * Expo/React Native — WebContainer can't run native code.
+         * Ask bolt to review the code instead of trying to boot the project.
+         */
+        localStorage.setItem(
+          'bolt_zip_autorun',
+          'This is an Expo/React Native project. Review the code structure and give me a summary of what the app does and how it is organized. Do not run any install or dev server commands — I will run this locally with Expo CLI.',
+        );
+      } else if (result.hasPackageJson) {
         localStorage.setItem('bolt_zip_autorun', 'Install the dependencies and start the development server.');
       }
 

--- a/app/components/chat/ImportZipButton.tsx
+++ b/app/components/chat/ImportZipButton.tsx
@@ -1,0 +1,100 @@
+import React, { useRef, useState } from 'react';
+import type { Message } from 'ai';
+import { toast } from 'react-toastify';
+import { createChatFromZip } from '~/utils/zipImport';
+import { logStore } from '~/lib/stores/logs';
+import { Button } from '~/components/ui/Button';
+import { classNames } from '~/utils/classNames';
+
+interface ImportZipButtonProps {
+  className?: string;
+  importChat?: (description: string, messages: Message[]) => Promise<void>;
+}
+
+export const ImportZipButton: React.FC<ImportZipButtonProps> = ({ className, importChat }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    const loadingToast = toast.loading(`Importing ${file.name}…`);
+
+    try {
+      const result = await createChatFromZip(file);
+
+      if (result.skippedBinary > 0) {
+        logStore.logWarning('Skipping binary files during ZIP import', {
+          zipName: file.name,
+          binaryCount: result.skippedBinary,
+        });
+        toast.info(`Skipping ${result.skippedBinary} binary file${result.skippedBinary === 1 ? '' : 's'}`);
+      }
+
+      /*
+       * Set flag before navigation so the new chat picks it up on mount.
+       * importChat does a full window.location.href redirect, so append()
+       * would be gone by the time it resolves.
+       */
+      if (result.hasPackageJson) {
+        localStorage.setItem('bolt_zip_autorun', 'Install the dependencies and start the development server.');
+      }
+
+      if (importChat) {
+        await importChat(file.name.replace(/\.zip$/i, ''), result.messages);
+      }
+
+      logStore.logSystem('ZIP imported successfully', {
+        zipName: file.name,
+        textFileCount: result.totalFiles - result.skippedBinary - result.skippedIgnored,
+        binaryFileCount: result.skippedBinary,
+        ignoredFileCount: result.skippedIgnored,
+      });
+
+      toast.success('ZIP imported successfully');
+    } catch (error) {
+      logStore.logError('Failed to import ZIP', error, { zipName: file.name });
+      console.error('Failed to import ZIP:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to import ZIP');
+    } finally {
+      setIsLoading(false);
+      toast.dismiss(loadingToast);
+
+      // Reset so the same file can be re-selected
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <>
+      <input ref={inputRef} type="file" className="hidden" accept=".zip" onChange={handleFileChange} />
+      <Button
+        onClick={() => inputRef.current?.click()}
+        title="Import ZIP"
+        variant="default"
+        size="lg"
+        className={classNames(
+          'gap-2 bg-bolt-elements-background-depth-1',
+          'text-bolt-elements-textPrimary',
+          'hover:bg-bolt-elements-background-depth-2',
+          'border border-bolt-elements-borderColor',
+          'h-10 px-4 py-2 min-w-[120px] justify-center',
+          'transition-all duration-200 ease-in-out',
+          className,
+        )}
+        disabled={isLoading}
+      >
+        <span className="i-ph:file-zip w-4 h-4" />
+        {isLoading ? 'Importing…' : 'Import ZIP'}
+      </Button>
+    </>
+  );
+};

--- a/app/components/chat/PromptQueuePanel.tsx
+++ b/app/components/chat/PromptQueuePanel.tsx
@@ -1,0 +1,239 @@
+import { useStore } from '@nanostores/react';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { promptQueueStore, loadQueue, startQueue, stopQueue } from '~/lib/stores/promptQueue';
+import { classNames } from '~/utils/classNames';
+
+/**
+ * Parses a raw string into an array of prompts.
+ *
+ * Supported formats (auto-detected, tried in order):
+ *  1. Code-block format  — content inside every ``` block is one prompt
+ *     (handles the "## PROMPT NNN\n```\n...\n```" style)
+ *  2. --- separator      — sections divided by horizontal rules
+ *  3. ## heading format  — sections divided by markdown headings
+ *  4. One prompt per line — plain newline-separated list (original fallback)
+ */
+function parsePrompts(raw: string): string[] {
+  const trimmed = raw.trim();
+
+  const codeBlockMatches = [...trimmed.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)];
+
+  if (codeBlockMatches.length > 0) {
+    return codeBlockMatches.map((m) => m[1].trim()).filter(Boolean);
+  }
+
+  if (/\n---+\n/.test(trimmed)) {
+    return trimmed
+      .split(/\n---+\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  if (/^#{1,3} /m.test(trimmed)) {
+    return trimmed
+      .split(/^#{1,3} .+$/m)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  return trimmed
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+interface PromptQueuePanelProps {
+  isStreaming: boolean;
+}
+
+export function PromptQueuePanel({ isStreaming }: PromptQueuePanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const { prompts, currentIndex, isRunning } = useStore(promptQueueStore);
+
+  const handleLoad = () => {
+    const parsed = parsePrompts(draft);
+
+    if (parsed.length === 0) {
+      toast.error('Enter at least one prompt');
+      return;
+    }
+
+    loadQueue(parsed);
+    toast.success(`Loaded ${parsed.length} prompt${parsed.length === 1 ? '' : 's'}`);
+  };
+
+  const handleStart = () => {
+    if (prompts.length === 0) {
+      toast.error('Load prompts first');
+      return;
+    }
+
+    if (isStreaming) {
+      toast.error('Wait for the current response to finish');
+      return;
+    }
+
+    startQueue();
+  };
+
+  const handleStop = () => {
+    stopQueue();
+    toast.info('Queue stopped');
+  };
+
+  const isAllDone = !isRunning && currentIndex === prompts.length && prompts.length > 0;
+  const progressLabel = isAllDone
+    ? `All ${prompts.length} prompts done ✓`
+    : isRunning
+      ? `Prompt ${currentIndex + 1} of ${prompts.length}`
+      : prompts.length > 0
+        ? `${prompts.length} prompt${prompts.length === 1 ? '' : 's'} loaded`
+        : '';
+
+  return (
+    <div className="relative border-t border-bolt-elements-borderColor">
+      {/* Toggle bar — always visible, minimal height */}
+      <button
+        onClick={() => setIsOpen((o) => !o)}
+        className={classNames(
+          'w-full flex items-center justify-between px-4 py-2 text-sm',
+          'bg-bolt-elements-background-depth-1',
+          'text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary',
+          'hover:bg-bolt-elements-background-depth-2 transition-colors',
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <span className="i-ph:queue w-4 h-4" />
+          <span>Prompt Queue</span>
+          {isRunning && (
+            <span className="flex items-center gap-1 text-green-500 text-xs">
+              <span className="i-ph:circle-notch w-3 h-3 animate-spin" />
+              <span>{progressLabel || 'Running'}</span>
+            </span>
+          )}
+          {!isRunning && progressLabel && (
+            <span className="text-xs text-bolt-elements-textTertiary">{progressLabel}</span>
+          )}
+        </span>
+        <span className={classNames('i-ph:caret-down w-4 h-4 transition-transform', isOpen ? 'rotate-180' : '')} />
+      </button>
+
+      {/* Expandable body — floats ABOVE the toggle, does not push chat layout */}
+      {isOpen && (
+        <div
+          className={classNames(
+            'absolute bottom-full left-0 right-0 z-50',
+            'mb-1 mx-2 rounded-xl',
+            'bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor',
+            'shadow-lg px-4 pb-4 pt-3 flex flex-col gap-3',
+          )}
+        >
+          {/* Tip */}
+          <p className="text-xs text-bolt-elements-textTertiary">
+            Tip: queues of 10–15 prompts work well. Longer runs may stall if bolt hits context limits or errors — use
+            Stop to recover and resume.
+          </p>
+
+          {/* Prompt editor */}
+          <textarea
+            className={classNames(
+              'w-full h-40 p-2 text-sm rounded-lg resize-none',
+              'bg-bolt-elements-background-depth-3',
+              'border border-bolt-elements-borderColor',
+              'text-bolt-elements-textPrimary placeholder:text-bolt-elements-textTertiary',
+              'focus:outline-none focus:ring-1 focus:ring-bolt-elements-focus',
+            )}
+            placeholder={
+              'Paste prompts in any format:\n• Code blocks (``` ... ```) — one prompt each\n• Sections divided by ---\n• ## Heading per prompt\n• Or just one prompt per line'
+            }
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={isRunning}
+          />
+
+          {/* Controls */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleLoad}
+              disabled={isRunning || !draft.trim()}
+              className={classNames(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                'text-bolt-elements-textPrimary hover:bg-bolt-elements-background-depth-2',
+                'disabled:opacity-40 disabled:cursor-not-allowed transition-colors',
+              )}
+            >
+              <span className="i-ph:upload-simple w-4 h-4" />
+              Load
+            </button>
+
+            {!isRunning ? (
+              <button
+                onClick={handleStart}
+                disabled={prompts.length === 0 || isStreaming}
+                className={classNames(
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                  'bg-green-600 hover:bg-green-500 text-white',
+                  'disabled:opacity-40 disabled:cursor-not-allowed transition-colors',
+                )}
+              >
+                <span className="i-ph:play w-4 h-4" />
+                Start
+              </button>
+            ) : (
+              <button
+                onClick={handleStop}
+                className={classNames(
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                  'bg-red-600 hover:bg-red-500 text-white transition-colors',
+                )}
+              >
+                <span className="i-ph:stop w-4 h-4" />
+                Stop
+              </button>
+            )}
+
+            {prompts.length > 0 && !isRunning && (
+              <span className="ml-auto text-xs text-bolt-elements-textTertiary">{progressLabel}</span>
+            )}
+          </div>
+
+          {/* Prompt list with status */}
+          {prompts.length > 0 && (
+            <ol className="flex flex-col gap-1 max-h-48 overflow-y-auto modern-scrollbar">
+              {prompts.map((prompt, i) => {
+                const isAllDone = !isRunning && currentIndex === prompts.length;
+                const isDone = isAllDone ? true : i < currentIndex;
+                const isActive = isRunning && i === currentIndex;
+                const isPending = !isDone && !isActive;
+
+                return (
+                  <li
+                    key={i}
+                    className={classNames(
+                      'flex items-start gap-2 px-2 py-1.5 rounded-lg text-xs',
+                      isActive ? 'bg-bolt-elements-background-depth-3 text-bolt-elements-textPrimary' : '',
+                      isDone ? 'text-bolt-elements-textTertiary line-through' : '',
+                      isPending && !isActive ? 'text-bolt-elements-textSecondary' : '',
+                    )}
+                  >
+                    <span className="mt-0.5 shrink-0">
+                      {isDone && <span className="i-ph:check-circle w-3.5 h-3.5 text-green-500" />}
+                      {isActive && <span className="i-ph:circle-notch w-3.5 h-3.5 text-blue-400 animate-spin" />}
+                      {isPending && !isActive && (
+                        <span className="i-ph:circle w-3.5 h-3.5 text-bolt-elements-textTertiary" />
+                      )}
+                    </span>
+                    <span className="truncate">{prompt}</span>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/chat/chatExportAndImport/ImportButtons.tsx
+++ b/app/components/chat/chatExportAndImport/ImportButtons.tsx
@@ -1,6 +1,7 @@
 import type { Message } from 'ai';
 import { toast } from 'react-toastify';
 import { ImportFolderButton } from '~/components/chat/ImportFolderButton';
+import { ImportZipButton } from '~/components/chat/ImportZipButton';
 import { Button } from '~/components/ui/Button';
 import { classNames } from '~/utils/classNames';
 
@@ -79,6 +80,17 @@ export function ImportButtons(importChat: ((description: string, messages: Messa
             Import Chat
           </Button>
           <ImportFolderButton
+            importChat={importChat}
+            className={classNames(
+              'gap-2 bg-bolt-elements-background-depth-1',
+              'text-bolt-elements-textPrimary',
+              'hover:bg-bolt-elements-background-depth-2',
+              'border border-[rgba(0,0,0,0.08)] dark:border-[rgba(255,255,255,0.08)]',
+              'h-10 px-4 py-2 min-w-[120px] justify-center',
+              'transition-all duration-200 ease-in-out rounded-lg',
+            )}
+          />
+          <ImportZipButton
             importChat={importChat}
             className={classNames(
               'gap-2 bg-bolt-elements-background-depth-1',

--- a/app/lib/stores/promptQueue.ts
+++ b/app/lib/stores/promptQueue.ts
@@ -1,0 +1,78 @@
+import { map } from 'nanostores';
+
+export interface PromptQueueState {
+  prompts: string[];
+  currentIndex: number;
+  isRunning: boolean;
+  pendingPrompt: string | null;
+}
+
+export const promptQueueStore = map<PromptQueueState>({
+  prompts: [],
+  currentIndex: 0,
+  isRunning: false,
+  pendingPrompt: null,
+});
+
+/** Load a fresh list of prompts (replaces any existing queue). */
+export function loadQueue(prompts: string[]) {
+  promptQueueStore.set({
+    prompts,
+    currentIndex: 0,
+    isRunning: false,
+    pendingPrompt: null,
+  });
+}
+
+/** Start the queue from the beginning and fire the first prompt. */
+export function startQueue() {
+  const { prompts } = promptQueueStore.get();
+
+  if (prompts.length === 0) {
+    return;
+  }
+
+  promptQueueStore.set({
+    prompts,
+    currentIndex: 0,
+    isRunning: true,
+    pendingPrompt: prompts[0],
+  });
+}
+
+/** Stop the queue without clearing the prompt list. */
+export function stopQueue() {
+  promptQueueStore.setKey('isRunning', false);
+  promptQueueStore.setKey('pendingPrompt', null);
+}
+
+/**
+ * Called by ChatImpl after onFinish fires.
+ * Advances to the next prompt or marks the queue done.
+ * Returns the next prompt string, or null if the queue is finished.
+ */
+export function advanceQueue(): string | null {
+  const { prompts, currentIndex, isRunning } = promptQueueStore.get();
+
+  if (!isRunning) {
+    return null;
+  }
+
+  const next = currentIndex + 1;
+
+  if (next >= prompts.length) {
+    /* Keep currentIndex at prompts.length so the UI shows all items as done */
+    promptQueueStore.set({ prompts, currentIndex: prompts.length, isRunning: false, pendingPrompt: null });
+    return null;
+  }
+
+  promptQueueStore.setKey('currentIndex', next);
+  promptQueueStore.setKey('pendingPrompt', prompts[next]);
+
+  return prompts[next];
+}
+
+/** Clear pending after ChatImpl has consumed it. */
+export function clearPendingPrompt() {
+  promptQueueStore.setKey('pendingPrompt', null);
+}

--- a/app/utils/zipImport.ts
+++ b/app/utils/zipImport.ts
@@ -1,0 +1,155 @@
+import type { Message } from 'ai';
+import JSZip from 'jszip';
+import { generateId, shouldIncludeFile } from './fileUtils';
+import { escapeBoltTags } from './projectCommands';
+
+/**
+ * Checks whether a Uint8Array looks like a binary file.
+ * Mirrors the logic in isBinaryFile (fileUtils.ts) but works directly
+ * with raw bytes instead of a browser File object.
+ */
+function isBinaryBuffer(buffer: Uint8Array): boolean {
+  const checkLength = Math.min(buffer.length, 1024);
+
+  for (let i = 0; i < checkLength; i++) {
+    const byte = buffer[i];
+
+    if (byte === 0 || (byte < 32 && byte !== 9 && byte !== 10 && byte !== 13)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Detects and returns a common root prefix that all file paths share
+ * (e.g. "my-project/" when macOS Compress or GitHub wraps everything
+ * in a top-level folder). Returns an empty string if there is no such
+ * prefix, or if the prefix would consume all path segments.
+ */
+function detectRootPrefix(paths: string[]): string {
+  if (paths.length === 0) {
+    return '';
+  }
+
+  const firstSegment = paths[0].split('/')[0] + '/';
+  const allSharePrefix = paths.every((p) => p.startsWith(firstSegment));
+
+  // Make sure the prefix is not the entire path of every file
+  const prefixIsWholeFile = paths.every((p) => p === firstSegment || p === firstSegment.slice(0, -1));
+
+  if (allSharePrefix && !prefixIsWholeFile && firstSegment !== '/') {
+    return firstSegment;
+  }
+
+  return '';
+}
+
+export interface ZipImportResult {
+  messages: Message[];
+  skippedBinary: number;
+  skippedIgnored: number;
+  totalFiles: number;
+  hasPackageJson: boolean;
+}
+
+/**
+ * Reads a ZIP file and converts its contents into the same boltArtifact
+ * chat-message structure that createChatFromFolder produces. This lets
+ * bolt load the project correctly without writing directly to the
+ * WebContainer filesystem (which can be wiped by navigation resets).
+ */
+export const createChatFromZip = async (zipFile: File): Promise<ZipImportResult> => {
+  const zip = new JSZip();
+  const contents = await zip.loadAsync(zipFile);
+
+  // Collect all non-directory entries
+  const allEntries = Object.entries(contents.files).filter(([, entry]) => !entry.dir);
+
+  if (allEntries.length === 0) {
+    throw new Error('The ZIP file contains no files.');
+  }
+
+  // Strip common root prefix (e.g. "my-project/" from macOS Compress)
+  const rawPaths = allEntries.map(([path]) => path);
+  const prefix = detectRootPrefix(rawPaths);
+
+  // Process every entry: resolve path, filter, read bytes
+  const fileArtifacts: Array<{ path: string; content: string }> = [];
+  const binaryFilePaths: string[] = [];
+  let skippedIgnored = 0;
+
+  for (const [rawPath, zipEntry] of allEntries) {
+    const relativePath = prefix ? rawPath.slice(prefix.length) : rawPath;
+
+    // Skip empty paths that arise when stripping the prefix of the root dir entry itself
+    if (!relativePath) {
+      continue;
+    }
+
+    // Apply the same ignore rules as ImportFolderButton
+    if (!shouldIncludeFile(relativePath)) {
+      skippedIgnored++;
+      continue;
+    }
+
+    const buffer = await zipEntry.async('uint8array');
+
+    if (isBinaryBuffer(buffer)) {
+      binaryFilePaths.push(relativePath);
+      continue;
+    }
+
+    const content = new TextDecoder('utf-8', { fatal: false }).decode(buffer);
+    fileArtifacts.push({ path: relativePath, content });
+  }
+
+  if (fileArtifacts.length === 0) {
+    throw new Error('No readable text files found in the ZIP (all files were binary or ignored).');
+  }
+
+  // Detect whether this is a Node project so we can craft the follow-up prompt
+  const hasPackageJson = fileArtifacts.some((f) => f.path === 'package.json' || f.path.endsWith('/package.json'));
+
+  const folderName = zipFile.name.replace(/\.zip$/i, '');
+
+  const binaryFilesMessage =
+    binaryFilePaths.length > 0
+      ? `\n\nSkipped ${binaryFilePaths.length} binary file${binaryFilePaths.length === 1 ? '' : 's'}:\n${binaryFilePaths.map((f) => `- ${f}`).join('\n')}`
+      : '';
+
+  const filesMessage: Message = {
+    role: 'assistant',
+    content: `I've imported the contents of the "${folderName}" ZIP archive.${binaryFilesMessage}
+
+<boltArtifact id="imported-files" title="Imported Files" type="bundled">
+${fileArtifacts
+  .map(
+    (file) => `<boltAction type="file" filePath="${file.path}">
+${escapeBoltTags(file.content)}
+</boltAction>`,
+  )
+  .join('\n\n')}
+</boltArtifact>`,
+    id: generateId(),
+    createdAt: new Date(),
+  };
+
+  const userMessage: Message = {
+    role: 'user',
+    id: generateId(),
+    content: `Import the "${folderName}" project from ZIP`,
+    createdAt: new Date(),
+  };
+
+  const messages: Message[] = [userMessage, filesMessage];
+
+  return {
+    messages,
+    skippedBinary: binaryFilePaths.length,
+    skippedIgnored,
+    totalFiles: fileArtifacts.length + binaryFilePaths.length + skippedIgnored,
+    hasPackageJson,
+  };
+};

--- a/app/utils/zipImport.ts
+++ b/app/utils/zipImport.ts
@@ -52,6 +52,7 @@ export interface ZipImportResult {
   skippedIgnored: number;
   totalFiles: number;
   hasPackageJson: boolean;
+  hasExpoConfig: boolean;
 }
 
 /**
@@ -112,6 +113,51 @@ export const createChatFromZip = async (zipFile: File): Promise<ZipImportResult>
   // Detect whether this is a Node project so we can craft the follow-up prompt
   const hasPackageJson = fileArtifacts.some((f) => f.path === 'package.json' || f.path.endsWith('/package.json'));
 
+  /*
+   * Detect Expo/React Native projects so we can suppress the "npm install
+   * and start dev server" prompt — WebContainer can't run native mobile code.
+   * We check for app.json / app.config.js (Expo-specific config files) or
+   * an "expo" key in the package.json dependencies.
+   */
+  const hasExpoConfig =
+    fileArtifacts.some((f) => f.path === 'app.json' || f.path === 'app.config.js' || f.path === 'app.config.ts') ||
+    fileArtifacts.some((f) => {
+      if (f.path !== 'package.json') {
+        return false;
+      }
+
+      try {
+        const pkg = JSON.parse(f.content);
+        return !!(pkg.dependencies?.expo || pkg.devDependencies?.expo);
+      } catch {
+        return false;
+      }
+    });
+
+  /*
+   * For Expo projects, strip the scripts from package.json so bolt has
+   * nothing to execute even if it tries. The user will run the project
+   * locally with Expo CLI. We preserve the rest of package.json intact.
+   */
+  if (hasExpoConfig) {
+    const pkgIndex = fileArtifacts.findIndex((f) => f.path === 'package.json');
+
+    if (pkgIndex !== -1) {
+      try {
+        const pkg = JSON.parse(fileArtifacts[pkgIndex].content);
+        pkg.scripts = {
+          _note: 'Run this project locally: npx expo start',
+        };
+        fileArtifacts[pkgIndex] = {
+          ...fileArtifacts[pkgIndex],
+          content: JSON.stringify(pkg, null, 2),
+        };
+      } catch {
+        /* If package.json is unparseable, leave it as-is */
+      }
+    }
+  }
+
   const folderName = zipFile.name.replace(/\.zip$/i, '');
 
   const binaryFilesMessage =
@@ -151,5 +197,6 @@ ${escapeBoltTags(file.content)}
     skippedIgnored,
     totalFiles: fileArtifacts.length + binaryFilePaths.length + skippedIgnored,
     hasPackageJson,
+    hasExpoConfig,
   };
 };


### PR DESCRIPTION
Prompt Queue — automated multi-step runs
Adds a collapsible Prompt Queue panel below the chat input that lets you load a list of prompts and run them sequentially without babysitting bolt between responses.
How it works:

Paste prompts in any format: ``` code blocks, --- separated sections, ## headings, or one per line
Hit Load then Start — the queue fires each prompt automatically after the previous response finishes
Stops automatically on error so bolt doesn't spiral

UI details:

Floats above the input as an overlay — doesn't push the chat layout
Collapsed bar shows live progress ("Prompt 3 of 10") while running
Expanded view shows each prompt with pending / spinning / strikethrough-done states
All strikethroughs persist after completion so you can see what ran
Tip copy sets expectations on practical queue length