### PR TITLE
feat(local-llm): prompt queue, shell safety, and main-thread performance

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -34,15 +34,21 @@ export const Artifact = memo(({ artifactId }: ArtifactProps) => {
   const artifacts = useStore(workbenchStore.artifacts);
   const artifact = artifacts[artifactId];
 
-  const actions = useStore(
-    computed(artifact.runner.actions, (actions) => {
-      // Filter out Supabase actions except for migrations
-      return Object.values(actions).filter((action) => {
-        // Exclude actions with type 'supabase' or actions that contain 'supabase' in their content
-        return action.type !== 'supabase' && !(action.type === 'shell' && action.content?.includes('supabase'));
-      });
-    }),
+  /*
+   * IMPORTANT: computed() must only be created once per component instance.
+   * Calling it inline recreates the store every render, giving `actions` a new
+   * reference each time and triggering an infinite useEffect → setState loop.
+   * useRef guarantees a single creation — safe because each Artifact mounts once
+   * for a fixed artifactId and artifact.runner never changes for that instance.
+   */
+  const actionsStoreRef = useRef(
+    computed(artifact.runner.actions, (actions) =>
+      Object.values(actions).filter(
+        (action) => action.type !== 'supabase' && !(action.type === 'shell' && action.content?.includes('supabase')),
+      ),
+    ),
   );
+  const actions = useStore(actionsStoreRef.current);
 
   const toggleActions = () => {
     userToggledActions.current = true;
@@ -59,11 +65,14 @@ export const Artifact = memo(({ artifactId }: ArtifactProps) => {
         (action) => action.status !== 'complete' && !(action.type === 'start' && action.status === 'running'),
       );
 
-      if (allActionFinished !== finished) {
-        setAllActionFinished(finished);
-      }
+      /*
+       * Always call setState — React bails out silently if the value hasn't
+       * changed, so this is safe and avoids having allActionFinished in deps
+       * (which would re-trigger this effect every time it updates).
+       */
+      setAllActionFinished(finished);
     }
-  }, [actions, artifact.type, allActionFinished]);
+  }, [actions, artifact.type]);
 
   // Determine the dynamic title based on state for bundled artifacts
   const dynamicTitle =

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -28,6 +28,8 @@ import type { ProgressAnnotation } from '~/types/context';
 import { SupabaseChatAlert } from '~/components/chat/SupabaseAlert';
 import { expoUrlAtom } from '~/lib/stores/qrCodeStore';
 import { useStore } from '@nanostores/react';
+import { PromptQueuePanel } from './PromptQueuePanel';
+import { LocalLlmPanel } from './LocalLLMPanel';
 import { StickToBottom, useStickToBottomContext } from '~/lib/hooks';
 import { ChatBox } from './ChatBox';
 import type { DesignScheme } from '~/types/design-scheme';
@@ -469,6 +471,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   setSelectedElement={setSelectedElement}
                   onWebSearchResult={onWebSearchResult}
                 />
+                <LocalLlmPanel />
+                {chatStarted && <PromptQueuePanel isStreaming={isStreaming} />}
               </div>
             </StickToBottom>
             <div className="flex flex-col justify-center">

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react';
 import type { Message } from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { useAnimate } from 'framer-motion';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, startTransition, useState } from 'react';
 import { toast } from 'react-toastify';
 import { useMessageParser, usePromptEnhancer, useShortcuts } from '~/lib/hooks';
 import { description, useChatHistory } from '~/lib/persistence';
@@ -21,6 +21,8 @@ import { createSampler } from '~/utils/sampler';
 import { getTemplates, selectStarterTemplate } from '~/utils/selectStarterTemplate';
 import { logStore } from '~/lib/stores/logs';
 import { streamingState } from '~/lib/stores/streaming';
+import { promptQueueStore, advanceQueue, clearPendingPrompt, stopQueue } from '~/lib/stores/promptQueue';
+import { localLLMSettingsStore, getTokenBudget, estimateTokens } from '~/lib/stores/localLLMSettings';
 import { filesToArtifacts } from '~/utils/fileUtils';
 import { supabaseConnection } from '~/lib/stores/supabase';
 import { defaultDesignScheme, type DesignScheme } from '~/types/design-scheme';
@@ -67,7 +69,34 @@ const processSampledMessages = createSampler(
     parseMessages(messages, isLoading);
 
     if (messages.length > initialMessages.length) {
-      storeMessageHistory(messages).catch((error) => toast.error(error.message));
+      /*
+       * Defer IndexedDB writes to avoid blocking the render thread.
+       * requestIdleCallback fires when the browser is idle between frames;
+       * setTimeout(0) is the fallback for browsers that don't support it.
+       */
+      const saveHistory = () => {
+        storeMessageHistory(messages).catch((error) => {
+          /*
+           * Suppress network/resource exhaustion errors — not actionable by the user
+           * and cascade into a flood of toasts when the browser is under memory pressure.
+           */
+          const msg: string = error?.message ?? '';
+          const isResourceError =
+            msg.includes('Failed to fetch') || msg.includes('ERR_INSUFFICIENT') || msg.includes('NetworkError');
+
+          if (!isResourceError) {
+            toast.error(msg);
+          } else {
+            console.warn('Chat history save failed (resource pressure):', msg);
+          }
+        });
+      };
+
+      if (typeof requestIdleCallback !== 'undefined') {
+        requestIdleCallback(saveHistory, { timeout: 2000 });
+      } else {
+        setTimeout(saveHistory, 0);
+      }
     }
   },
   50,
@@ -101,6 +130,10 @@ export const ChatImpl = memo(
     );
     const supabaseAlert = useStore(workbenchStore.supabaseAlert);
     const { activeProviders, promptId, autoSelectTemplate, contextOptimizationEnabled } = useSettings();
+    const localLLMSettings = useStore(localLLMSettingsStore);
+
+    // When slim system prompt is enabled, override promptId to 'slim'
+    const effectivePromptId = localLLMSettings.slimSystemPrompt ? 'slim' : promptId;
     const [llmErrorAlert, setLlmErrorAlert] = useState<LlmErrorAlertType | undefined>(undefined);
     const [model, setModel] = useState(() => {
       const savedModel = Cookies.get('selectedModel');
@@ -136,8 +169,20 @@ export const ChatImpl = memo(
       body: {
         apiKeys,
         files,
-        promptId,
-        contextOptimization: contextOptimizationEnabled,
+        promptId: effectivePromptId,
+
+        /*
+         * Disable bolt's context-file-selection pass when local models are
+         * active — it runs a separate LLM call that times out with Ollama,
+         * and fails on new files that don't exist in WebContainer yet.
+         */
+        /*
+         * Context optimization is now safe for local models — the server wraps both
+         * LLM pre-passes in a timeout and falls back to keyword-based file selection
+         * if Ollama is too slow. Only hard-disable if the user explicitly opted out.
+         */
+        contextOptimization: localLLMSettings.disableContextOptimization ? false : contextOptimizationEnabled,
+        isLocalModel: localLLMSettings.enableLocalModels && localLLMSettings.extendedStreamTimeout,
         chatMode,
         designScheme,
         supabase: {
@@ -154,6 +199,7 @@ export const ChatImpl = memo(
       onError: (e) => {
         setFakeLoading(false);
         handleError(e, 'chat');
+        stopQueue();
       },
       onFinish: (message, response) => {
         const usage = response.usage;
@@ -172,6 +218,204 @@ export const ChatImpl = memo(
         }
 
         logger.debug('Finished streaming');
+
+        /*
+         * Collect all transformation inputs synchronously (before any async yields),
+         * then apply all message mutations in a SINGLE startTransition-wrapped setMessages
+         * call. This prevents 4 separate render cycles for each queue step and keeps the
+         * UI responsive — startTransition marks this batch as non-urgent so React can
+         * yield to user interactions (clicks, scrolls) between work chunks.
+         */
+
+        // Inputs for pass 1: ZIP import compaction
+        const zipFiletreeRaw = localStorage.getItem('bolt_zip_filetree');
+
+        if (zipFiletreeRaw) {
+          localStorage.removeItem('bolt_zip_filetree');
+        }
+
+        // Inputs for pass 2+: queue state and settings
+        const { isRunning } = promptQueueStore.get();
+        const llmSettings = localLLMSettingsStore.get();
+        const tokenBudget = getTokenBudget(llmSettings);
+
+        startTransition(() => {
+          setMessages((prev) => {
+            let msgs = prev;
+
+            // --- Pass 1: ZIP import — replace giant boltArtifact with compact file tree ---
+            if (zipFiletreeRaw) {
+              try {
+                const { folderName, fileCount, tree } = JSON.parse(zipFiletreeRaw);
+                const compactContent = `I've imported the "${folderName}" project (${fileCount} files). All files have been written to the WebContainer filesystem.\n\nProject structure:\n${tree}\n\nFiles are ready — I'll use context selection to pull relevant files as needed for each task.`;
+                msgs = msgs.map((m) =>
+                  m.content.includes('boltArtifact id="imported-files"') ? { ...m, content: compactContent } : m,
+                );
+              } catch {
+                /* ignore parse errors */
+              }
+            }
+
+            // --- Pass 2: Queue artifact pruning — strip boltArtifact from older messages ---
+            if (isRunning) {
+              const assistantMsgs = msgs.filter((m) => m.role === 'assistant');
+              const keepRecent = 2;
+              const pruneCount = Math.max(0, assistantMsgs.length - keepRecent);
+
+              if (pruneCount > 0) {
+                let pruned = 0;
+                msgs = msgs.map((m) => {
+                  if (m.role !== 'assistant' || pruned >= pruneCount) {
+                    return m;
+                  }
+
+                  if (m.content.includes('<boltArtifact')) {
+                    pruned++;
+                    return {
+                      ...m,
+                      content: m.content.replace(
+                        /<boltArtifact[\s\S]*?<\/boltArtifact>/g,
+                        '[files applied to WebContainer]',
+                      ),
+                    };
+                  }
+
+                  return m;
+                });
+              }
+            }
+
+            // --- Pass 3: Local LLM optimizations — dedup file writes and strip old prose ---
+            if (llmSettings.dedupFileWrites || llmSettings.stripOldProse) {
+              if (llmSettings.dedupFileWrites) {
+                /*
+                 * Walk messages newest-first, track file paths already seen.
+                 * For any older write of the same path, replace with a stub so
+                 * the model doesn't re-read stale file versions.
+                 */
+                const seenPaths = new Set<string>();
+
+                msgs = msgs
+                  .slice()
+                  .reverse()
+                  .map((m) => {
+                    if (m.role !== 'assistant' || !m.content.includes('<boltArtifact')) {
+                      return m;
+                    }
+
+                    const newContent = m.content.replace(
+                      /<boltAction type="file" filePath="([^"]+)">([\s\S]*?)<\/boltAction>/g,
+                      (match, filePath) => {
+                        if (seenPaths.has(filePath)) {
+                          return `<boltAction type="file" filePath="${filePath}">[superseded by later write]</boltAction>`;
+                        }
+
+                        seenPaths.add(filePath);
+
+                        return match;
+                      },
+                    );
+
+                    return newContent !== m.content ? { ...m, content: newContent } : m;
+                  })
+                  .reverse();
+              }
+
+              if (llmSettings.stripOldProse) {
+                /*
+                 * For assistant messages older than the last 2, strip everything
+                 * outside <boltArtifact> tags. The prose is already read — keeping
+                 * it is pure token cost.
+                 */
+                const assistantIndices = msgs.map((m, i) => (m.role === 'assistant' ? i : -1)).filter((i) => i >= 0);
+                const pruneSet = new Set(assistantIndices.slice(0, Math.max(0, assistantIndices.length - 2)));
+
+                msgs = msgs.map((m, i) => {
+                  if (!pruneSet.has(i)) {
+                    return m;
+                  }
+
+                  if (!m.content.includes('<boltArtifact')) {
+                    return { ...m, content: '[response]' };
+                  }
+
+                  const artifacts = [...m.content.matchAll(/<boltArtifact[\s\S]*?<\/boltArtifact>/g)]
+                    .map((match) => match[0])
+                    .join('\n');
+
+                  return { ...m, content: artifacts || '[response]' };
+                });
+              }
+            }
+
+            // --- Pass 4: Token-budget pruning — trim oldest messages until under budget ---
+            if (tokenBudget !== null) {
+              const totalTokens = msgs.reduce((sum, m) => sum + estimateTokens(String(m.content)), 0);
+
+              if (totalTokens > tokenBudget) {
+                const KEEP_TAIL = 4;
+
+                if (msgs.length > KEEP_TAIL + 1) {
+                  const head = msgs.slice(0, 1);
+                  const tail = msgs.slice(-KEEP_TAIL);
+                  let middle = msgs.slice(1, -KEEP_TAIL);
+
+                  while (
+                    middle.length > 0 &&
+                    head.concat(middle, tail).reduce((sum, m) => sum + estimateTokens(String(m.content)), 0) >
+                      tokenBudget
+                  ) {
+                    middle = middle.slice(1);
+                  }
+
+                  msgs = [...head, ...middle, ...tail];
+                }
+              }
+            }
+
+            return msgs;
+          });
+        });
+
+        /* Advance the prompt queue if one is running */
+        const nextPrompt = advanceQueue();
+
+        if (nextPrompt) {
+          /* Small delay so the UI can settle before the next message fires */
+          /*
+           * Wait for the action runner to fully settle (all file writes / shell
+           * commands reach a terminal state) before firing the next prompt.
+           * This prevents WebContainer from being overwhelmed by rapid-fire writes.
+           * Falls back after maxWaitMs regardless so the queue never stalls forever.
+           */
+          const waitForActionsToSettle = (maxWaitMs = 60_000): Promise<void> =>
+            new Promise((resolve) => {
+              const deadline = Date.now() + maxWaitMs;
+
+              const check = () => {
+                const artifacts = workbenchStore.artifacts.get();
+                const anyBusy = Object.values(artifacts).some((artifact) =>
+                  Object.values(artifact.runner.actions.get()).some(
+                    (action) => action.status === 'running' || action.status === 'pending',
+                  ),
+                );
+
+                if (!anyBusy || Date.now() >= deadline) {
+                  // Extra breathing room after actions settle so WebContainer can flush I/O
+                  setTimeout(resolve, 1500);
+                } else {
+                  setTimeout(check, 500);
+                }
+              };
+
+              // Give the action runner a moment to start before we start polling
+              setTimeout(check, 1000);
+            });
+
+          waitForActionsToSettle().then(() => {
+            promptQueueStore.setKey('pendingPrompt', nextPrompt);
+          });
+        }
       },
       initialMessages,
       initialInput: Cookies.get(PROMPT_COOKIE_KEY) || '',
@@ -199,6 +443,38 @@ export const ChatImpl = memo(
     useEffect(() => {
       chatStore.setKey('started', initialMessages.length > 0);
     }, []);
+
+    /*
+     * Pre-fill the textarea with the follow-up prompt set by ImportZipButton before the
+     * full-page navigation. Using setInput instead of append so the user confirms with
+     * one Enter keystroke — avoids model-state race conditions on chat initialisation.
+     */
+    useEffect(() => {
+      if (initialMessages.length === 0) {
+        return;
+      }
+
+      const autorun = localStorage.getItem('bolt_zip_autorun');
+
+      if (autorun) {
+        localStorage.removeItem('bolt_zip_autorun');
+        setInput(autorun);
+      }
+    }, []);
+
+    /* Fire the next queued prompt whenever the store signals one is ready */
+    useEffect(() => {
+      const unsubscribe = promptQueueStore.subscribe((state) => {
+        if (state.pendingPrompt) {
+          clearPendingPrompt();
+
+          const messageText = `[Model: ${model}]\n\n[Provider: ${provider.name}]\n\n${state.pendingPrompt}`;
+          append({ role: 'user', content: messageText });
+        }
+      });
+
+      return unsubscribe;
+    }, [append, model, provider]);
 
     useEffect(() => {
       processSampledMessages({

--- a/app/components/chat/ImportZipButton.tsx
+++ b/app/components/chat/ImportZipButton.tsx
@@ -1,0 +1,128 @@
+import React, { useRef, useState } from 'react';
+import type { Message } from 'ai';
+import { toast } from 'react-toastify';
+import { createChatFromZip } from '~/utils/zipImport';
+import { logStore } from '~/lib/stores/logs';
+import { Button } from '~/components/ui/Button';
+import { classNames } from '~/utils/classNames';
+
+interface ImportZipButtonProps {
+  className?: string;
+  importChat?: (description: string, messages: Message[]) => Promise<void>;
+}
+
+export const ImportZipButton: React.FC<ImportZipButtonProps> = ({ className, importChat }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    const loadingToast = toast.loading(`Importing ${file.name}…`);
+
+    try {
+      const result = await createChatFromZip(file);
+
+      if (result.skippedBinary > 0) {
+        logStore.logWarning('Skipping binary files during ZIP import', {
+          zipName: file.name,
+          binaryCount: result.skippedBinary,
+        });
+        toast.info(`Skipping ${result.skippedBinary} binary file${result.skippedBinary === 1 ? '' : 's'}`);
+      }
+
+      /*
+       * Set flag before navigation so the new chat picks it up on mount.
+       * importChat does a full window.location.href redirect, so append()
+       * would be gone by the time it resolves.
+       */
+      /*
+       * Store file tree so Chat.client can replace the giant artifact message
+       * with a compact summary after bolt has written the files to WebContainer.
+       */
+      localStorage.setItem(
+        'bolt_zip_filetree',
+        JSON.stringify({
+          folderName: file.name.replace(/\.zip$/i, ''),
+          fileCount: result.totalFiles - result.skippedBinary - result.skippedIgnored,
+          tree: result.fileTreeSummary,
+        }),
+      );
+
+      if (result.boltPrompt) {
+        /*
+         * Project includes a .bolt/prompt file — use its contents verbatim
+         * as the auto-fill first message, overriding all defaults.
+         */
+        localStorage.setItem('bolt_zip_autorun', result.boltPrompt);
+      } else if (result.hasExpoConfig) {
+        /*
+         * Expo/React Native — WebContainer can't run native code.
+         * Ask bolt to review the code instead of trying to boot the project.
+         */
+        localStorage.setItem(
+          'bolt_zip_autorun',
+          'This is an Expo/React Native project. Review the code structure and give me a summary of what the app does and how it is organized. Do not run any install or dev server commands — I will run this locally with Expo CLI.',
+        );
+      } else if (result.hasPackageJson) {
+        localStorage.setItem('bolt_zip_autorun', 'Install the dependencies and start the development server.');
+      }
+
+      if (importChat) {
+        await importChat(file.name.replace(/\.zip$/i, ''), result.messages);
+      }
+
+      logStore.logSystem('ZIP imported successfully', {
+        zipName: file.name,
+        textFileCount: result.totalFiles - result.skippedBinary - result.skippedIgnored,
+        binaryFileCount: result.skippedBinary,
+        ignoredFileCount: result.skippedIgnored,
+      });
+
+      toast.success('ZIP imported successfully');
+    } catch (error) {
+      logStore.logError('Failed to import ZIP', error, { zipName: file.name });
+      console.error('Failed to import ZIP:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to import ZIP');
+    } finally {
+      setIsLoading(false);
+      toast.dismiss(loadingToast);
+
+      // Reset so the same file can be re-selected
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <>
+      <input ref={inputRef} type="file" className="hidden" accept=".zip" onChange={handleFileChange} />
+      <Button
+        onClick={() => inputRef.current?.click()}
+        title="Import ZIP"
+        variant="default"
+        size="lg"
+        className={classNames(
+          'gap-2 bg-bolt-elements-background-depth-1',
+          'text-bolt-elements-textPrimary',
+          'hover:bg-bolt-elements-background-depth-2',
+          'border border-bolt-elements-borderColor',
+          'h-10 px-4 py-2 min-w-[120px] justify-center',
+          'transition-all duration-200 ease-in-out',
+          className,
+        )}
+        disabled={isLoading}
+      >
+        <span className="i-ph:file-zip w-4 h-4" />
+        {isLoading ? 'Importing…' : 'Import ZIP'}
+      </Button>
+    </>
+  );
+};

--- a/app/components/chat/LocalLLMPanel.tsx
+++ b/app/components/chat/LocalLLMPanel.tsx
@@ -1,0 +1,226 @@
+import { useStore } from '@nanostores/react';
+import { useRef, useState } from 'react';
+import { localLLMSettingsStore, updateLocalLLMSettings, type TokenBudget } from '~/lib/stores/localLLMSettings';
+import { classNames } from '~/utils/classNames';
+
+export function LocalLlmPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({});
+  const barRef = useRef<HTMLDivElement>(null);
+  const settings = useStore(localLLMSettingsStore);
+
+  const handleToggle = () => {
+    if (!isOpen && barRef.current) {
+      const rect = barRef.current.getBoundingClientRect();
+      setPanelStyle({
+        bottom: window.innerHeight - rect.top,
+        left: rect.left,
+        width: rect.width,
+
+        // Clamp height so panel never overflows above the viewport
+        maxHeight: Math.min(rect.top - 8, window.innerHeight * 0.85),
+      });
+    }
+
+    setIsOpen((o) => !o);
+  };
+
+  const toggle = (key: keyof typeof settings) => {
+    updateLocalLLMSettings({ [key]: !settings[key] } as any);
+  };
+
+  const handleTokenBudget = (value: TokenBudget) => {
+    updateLocalLLMSettings({ tokenBudget: value });
+  };
+
+  return (
+    <div ref={barRef} className="relative border-t border-bolt-elements-borderColor bg-gray-100 dark:bg-gray-900">
+      {/* Toggle bar */}
+      <button
+        onClick={handleToggle}
+        className={classNames(
+          'w-full flex items-center justify-between px-4 py-2 text-sm',
+          'bg-transparent text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary',
+          'hover:bg-bolt-elements-background-depth-2 transition-colors',
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <span className="i-ph:cpu w-4 h-4" />
+          <span>Local Models</span>
+          {settings.enableLocalModels && (
+            <span className="flex items-center gap-1 text-green-500 text-xs">
+              <span className="i-ph:check-circle w-3 h-3" />
+              <span>enabled</span>
+            </span>
+          )}
+        </span>
+        <span className={classNames('i-ph:caret-down w-4 h-4 transition-transform', isOpen ? 'rotate-180' : '')} />
+      </button>
+
+      {/* Expandable panel — floats above the bar, does not push chat layout */}
+      {isOpen && (
+        <div
+          style={panelStyle}
+          className={classNames(
+            'fixed z-[9999]',
+            'mb-1 rounded-xl',
+            'bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor',
+            'shadow-lg px-4 pb-4 pt-3 flex flex-col gap-3',
+            'overflow-y-auto modern-scrollbar',
+          )}
+        >
+          {/* Enable local models */}
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={settings.enableLocalModels}
+                onChange={() => toggle('enableLocalModels')}
+                className="w-4 h-4 rounded accent-green-500"
+              />
+              <span className="text-sm text-bolt-elements-textPrimary font-medium">Enable Local Models</span>
+              <span className="text-xs text-bolt-elements-textTertiary">(Ollama &amp; LMStudio)</span>
+            </label>
+
+            {settings.enableLocalModels && (
+              <div className="ml-6 flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-bolt-elements-textTertiary w-20 shrink-0">Ollama URL</span>
+                  <input
+                    type="text"
+                    value={settings.ollamaBaseUrl}
+                    onChange={(e) => updateLocalLLMSettings({ ollamaBaseUrl: e.target.value })}
+                    onBlur={(e) => updateLocalLLMSettings({ ollamaBaseUrl: e.target.value })}
+                    className={classNames(
+                      'flex-1 px-2 py-1 text-xs rounded-lg',
+                      'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                      'text-bolt-elements-textPrimary',
+                      'focus:outline-none focus:ring-1 focus:ring-bolt-elements-focus',
+                    )}
+                    placeholder="http://localhost:11434"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-bolt-elements-textTertiary w-20 shrink-0">LMStudio URL</span>
+                  <input
+                    type="text"
+                    value={settings.lmstudioBaseUrl}
+                    onChange={(e) => updateLocalLLMSettings({ lmstudioBaseUrl: e.target.value })}
+                    onBlur={(e) => updateLocalLLMSettings({ lmstudioBaseUrl: e.target.value })}
+                    className={classNames(
+                      'flex-1 px-2 py-1 text-xs rounded-lg',
+                      'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                      'text-bolt-elements-textPrimary',
+                      'focus:outline-none focus:ring-1 focus:ring-bolt-elements-focus',
+                    )}
+                    placeholder="http://localhost:1234"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-bolt-elements-borderColor" />
+
+          {/* Context optimizations — 2-column grid, descriptions as tooltips */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold text-bolt-elements-textTertiary uppercase tracking-wide">
+              Context Optimizations
+            </span>
+
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+              {(
+                [
+                  {
+                    key: 'slimSystemPrompt',
+                    label: 'Slim system prompt',
+                    tip: 'Stripped-down system prompt for models under 13B. Removes WebContainer constraints and verbose copy.',
+                  },
+                  {
+                    key: 'dedupFileWrites',
+                    label: 'Dedup file writes',
+                    tip: 'Keeps only the most recent write per file in history — removes stale older versions from context.',
+                  },
+                  {
+                    key: 'stripOldProse',
+                    label: 'Strip old prose',
+                    tip: 'Removes explanation text from older assistant messages, keeping only boltArtifact blocks.',
+                  },
+                  {
+                    key: 'disableContextOptimization',
+                    label: 'Skip context pre-pass',
+                    tip: 'Skips the LLM file-selection pre-pass entirely. Use if the pre-pass is causing timeouts.',
+                  },
+                  {
+                    key: 'extendedStreamTimeout',
+                    label: 'Extended timeout (3 min)',
+                    tip: 'Uses 3-minute stream timeout instead of 45 s. Needed for local models with slow startup. Disable for cloud APIs.',
+                  },
+                  {
+                    key: 'blockHangingCommands',
+                    label: 'Block install/server cmds',
+                    tip: 'Blocks npm install, expo start, yarn, etc. — commands that hang WebContainer. Run them locally instead.',
+                  },
+                ] as { key: keyof typeof settings; label: string; tip: string }[]
+              ).map(({ key, label, tip }) => (
+                <label key={key} title={tip} className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={!!settings[key]}
+                    onChange={() => toggle(key)}
+                    className="w-4 h-4 rounded accent-green-500 shrink-0"
+                  />
+                  <span className="text-xs text-bolt-elements-textPrimary leading-tight">{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-t border-bolt-elements-borderColor" />
+
+          {/* Token budget */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold text-bolt-elements-textTertiary uppercase tracking-wide">
+              Token Budget
+              <span className="ml-2 normal-case font-normal text-bolt-elements-textTertiary">
+                — prune history when over limit
+              </span>
+            </span>
+
+            <div className="flex gap-4">
+              {(['off', '20k', '40k', 'custom'] as TokenBudget[]).map((val) => (
+                <label key={val} className="flex items-center gap-1.5 cursor-pointer select-none">
+                  <input
+                    type="radio"
+                    name="tokenBudget"
+                    value={val}
+                    checked={settings.tokenBudget === val}
+                    onChange={() => handleTokenBudget(val)}
+                    className="w-3.5 h-3.5 accent-green-500"
+                  />
+                  <span className="text-xs text-bolt-elements-textPrimary capitalize">{val}</span>
+                </label>
+              ))}
+              {settings.tokenBudget === 'custom' && (
+                <input
+                  type="number"
+                  min={4000}
+                  max={200000}
+                  step={1000}
+                  value={settings.tokenBudgetCustom}
+                  onChange={(e) => updateLocalLLMSettings({ tokenBudgetCustom: Number(e.target.value) })}
+                  className={classNames(
+                    'w-24 px-2 py-0.5 text-xs rounded-lg',
+                    'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                    'text-bolt-elements-textPrimary',
+                    'focus:outline-none focus:ring-1 focus:ring-bolt-elements-focus',
+                  )}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/chat/PromptQueuePanel.tsx
+++ b/app/components/chat/PromptQueuePanel.tsx
@@ -1,0 +1,356 @@
+import { useStore } from '@nanostores/react';
+import { useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+import { promptQueueStore, loadQueue, startQueue, stopQueue, resumeQueue, clearQueue } from '~/lib/stores/promptQueue';
+import { classNames } from '~/utils/classNames';
+
+/**
+ * Parses a raw string into an array of prompts.
+ *
+ * Supported formats (auto-detected, tried in order):
+ *  1. Code-block format  — content inside every ``` block is one prompt
+ *     (handles the "## PROMPT NNN\n```\n...\n```" style)
+ *  2. --- separator      — sections divided by horizontal rules
+ *  3. ## heading format  — sections divided by markdown headings
+ *  4. One prompt per line — plain newline-separated list (original fallback)
+ */
+function parsePrompts(raw: string): string[] {
+  const trimmed = raw.trim();
+
+  const codeBlockMatches = [...trimmed.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)];
+
+  if (codeBlockMatches.length > 0) {
+    return codeBlockMatches.map((m) => m[1].trim()).filter(Boolean);
+  }
+
+  if (/\n---+\n/.test(trimmed)) {
+    return trimmed
+      .split(/\n---+\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  // ####Prompt N#### delimiter style
+  if (/^####[^#\n]+####$/m.test(trimmed)) {
+    return trimmed
+      .split(/^####[^#\n]+####$/m)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  if (/^#{1,3} /m.test(trimmed)) {
+    return trimmed
+      .split(/^#{1,3} .+$/m)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  return trimmed
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+interface PromptQueuePanelProps {
+  isStreaming: boolean;
+}
+
+export function PromptQueuePanel({ isStreaming }: PromptQueuePanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({});
+  const barRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState('');
+  const { prompts, currentIndex, isRunning } = useStore(promptQueueStore);
+
+  const handleLoad = () => {
+    const parsed = parsePrompts(draft);
+
+    if (parsed.length === 0) {
+      toast.error('Enter at least one prompt');
+      return;
+    }
+
+    loadQueue(parsed);
+    toast.success(`Loaded ${parsed.length} prompt${parsed.length === 1 ? '' : 's'}`);
+  };
+
+  const isAllDone = !isRunning && prompts.length > 0 && currentIndex > 0 && currentIndex === prompts.length;
+  const isPaused = !isRunning && currentIndex > 0 && currentIndex < prompts.length;
+  const hasPrompts = prompts.length > 0;
+
+  const progressLabel = isAllDone
+    ? `All ${prompts.length} prompts done ✓`
+    : isRunning
+      ? `Prompt ${currentIndex + 1} of ${prompts.length}`
+      : isPaused
+        ? `Paused at ${currentIndex + 1} of ${prompts.length}`
+        : hasPrompts
+          ? `${prompts.length} prompt${prompts.length === 1 ? '' : 's'} loaded`
+          : '';
+
+  const handleStop = () => {
+    stopQueue();
+    toast.info('Queue paused — current response will finish');
+  };
+
+  const handleClear = () => {
+    clearQueue();
+    setDraft('');
+    toast.info('Queue cleared');
+  };
+
+  return (
+    <div ref={barRef} className="relative border-t border-bolt-elements-borderColor bg-gray-100 dark:bg-gray-900">
+      {/* Toggle bar — always visible */}
+      <div className="w-full flex items-center px-4 py-2 text-sm gap-2">
+        {/* Clickable label area */}
+        <button
+          onClick={() => {
+            if (!isOpen && barRef.current) {
+              const rect = barRef.current.getBoundingClientRect();
+              setPanelStyle({ bottom: window.innerHeight - rect.top, left: rect.left, width: rect.width });
+            }
+
+            setIsOpen((o) => !o);
+          }}
+          className={classNames(
+            'flex items-center gap-2 flex-1 min-w-0 bg-transparent',
+            'text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary transition-colors',
+          )}
+        >
+          <span className="i-ph:queue w-4 h-4 shrink-0" />
+          <span className="shrink-0">Prompt Queue</span>
+          {isRunning && (
+            <span className="flex items-center gap-1 text-green-500 text-xs">
+              <span className="i-ph:circle-notch w-3 h-3 animate-spin" />
+              <span>{progressLabel}</span>
+            </span>
+          )}
+          {!isRunning && progressLabel && (
+            <span
+              className={classNames(
+                'text-xs truncate',
+                isPaused ? 'text-yellow-500' : 'text-bolt-elements-textTertiary',
+              )}
+            >
+              {progressLabel}
+            </span>
+          )}
+        </button>
+
+        {/* Inline action buttons on the collapsed bar */}
+        <div className="flex items-center gap-1 shrink-0">
+          {isRunning && (
+            <button
+              onClick={handleStop}
+              title="Stop after this response"
+              className={classNames(
+                'flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                'bg-red-600 hover:bg-red-500 text-white transition-colors',
+              )}
+            >
+              <span className="i-ph:stop w-3.5 h-3.5" />
+              Stop
+            </button>
+          )}
+          {!isRunning && isPaused && (
+            <button
+              onClick={() => {
+                if (!isStreaming) {
+                  resumeQueue();
+                } else {
+                  toast.error('Wait for the current response to finish');
+                }
+              }}
+              title="Resume from current step"
+              className={classNames(
+                'flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                'bg-green-600 hover:bg-green-500 text-white transition-colors',
+              )}
+            >
+              <span className="i-ph:play w-3.5 h-3.5" />
+              Resume
+            </button>
+          )}
+          {!isRunning && hasPrompts && !isAllDone && !isPaused && (
+            <button
+              onClick={() => {
+                if (!isStreaming) {
+                  startQueue();
+                } else {
+                  toast.error('Wait for the current response to finish');
+                }
+              }}
+              title="Start queue"
+              className={classNames(
+                'flex items-center gap-1 px-2 py-1 rounded-lg text-xs',
+                'bg-green-600 hover:bg-green-500 text-white transition-colors',
+              )}
+            >
+              <span className="i-ph:play w-3.5 h-3.5" />
+              Start
+            </button>
+          )}
+        </div>
+
+        <button
+          onClick={() => {
+            if (!isOpen && barRef.current) {
+              const rect = barRef.current.getBoundingClientRect();
+              setPanelStyle({ bottom: window.innerHeight - rect.top, left: rect.left, width: rect.width });
+            }
+
+            setIsOpen((o) => !o);
+          }}
+          className="text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary transition-colors shrink-0"
+        >
+          <span
+            className={classNames('i-ph:caret-down w-4 h-4 transition-transform block', isOpen ? 'rotate-180' : '')}
+          />
+        </button>
+      </div>
+
+      {/* Expandable body — floats ABOVE the toggle, does not push chat layout */}
+      {isOpen && (
+        <div
+          style={panelStyle}
+          className={classNames(
+            'fixed z-[9999]',
+            'mb-1 rounded-xl',
+            'bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor',
+            'shadow-lg px-4 pb-4 pt-3 flex flex-col gap-3',
+            'max-h-[80vh] overflow-y-auto modern-scrollbar',
+          )}
+        >
+          {/* Tip */}
+          <p className="text-xs text-bolt-elements-textTertiary">
+            Tip: queues of 10–15 prompts work well. Longer runs may stall if bolt hits context limits or errors — use
+            Stop to recover and resume.
+          </p>
+
+          {/* Prompt editor */}
+          <textarea
+            className={classNames(
+              'w-full h-40 p-2 text-sm rounded-lg resize-none',
+              'bg-bolt-elements-background-depth-3',
+              'border border-bolt-elements-borderColor',
+              'text-bolt-elements-textPrimary placeholder:text-bolt-elements-textTertiary',
+              'focus:outline-none focus:ring-1 focus:ring-bolt-elements-focus',
+            )}
+            placeholder={
+              'Paste prompts in any format:\n• Code blocks (``` ... ```) — one prompt each\n• Sections divided by ---\n• ## Heading per prompt\n• Or just one prompt per line'
+            }
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={isRunning}
+          />
+
+          {/* Controls */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              onClick={handleLoad}
+              disabled={isRunning || !draft.trim()}
+              className={classNames(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                'text-bolt-elements-textPrimary hover:bg-bolt-elements-background-depth-2',
+                'disabled:opacity-40 disabled:cursor-not-allowed transition-colors',
+              )}
+            >
+              <span className="i-ph:upload-simple w-4 h-4" />
+              Load
+            </button>
+
+            {!isRunning && isPaused && (
+              <button
+                onClick={() => {
+                  if (!isStreaming) {
+                    resumeQueue();
+                  } else {
+                    toast.error('Wait for the current response to finish');
+                  }
+                }}
+                disabled={isStreaming}
+                className={classNames(
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                  'bg-green-600 hover:bg-green-500 text-white',
+                  'disabled:opacity-40 disabled:cursor-not-allowed transition-colors',
+                )}
+              >
+                <span className="i-ph:play w-4 h-4" />
+                Resume
+              </button>
+            )}
+
+            {isRunning && (
+              <button
+                onClick={handleStop}
+                className={classNames(
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                  'bg-red-600 hover:bg-red-500 text-white transition-colors',
+                )}
+              >
+                <span className="i-ph:stop w-4 h-4" />
+                Stop
+              </button>
+            )}
+
+            {hasPrompts && (
+              <button
+                onClick={handleClear}
+                disabled={isRunning}
+                title="Clear queue"
+                className={classNames(
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm',
+                  'bg-bolt-elements-background-depth-3 border border-bolt-elements-borderColor',
+                  'text-bolt-elements-textSecondary hover:text-red-400 hover:border-red-400',
+                  'disabled:opacity-40 disabled:cursor-not-allowed transition-colors',
+                )}
+              >
+                <span className="i-ph:trash w-4 h-4" />
+                Clear
+              </button>
+            )}
+
+            {hasPrompts && !isRunning && (
+              <span className="ml-auto text-xs text-bolt-elements-textTertiary">{progressLabel}</span>
+            )}
+          </div>
+
+          {/* Prompt list with status */}
+          {prompts.length > 0 && (
+            <ol className="flex flex-col gap-1 max-h-48 overflow-y-auto modern-scrollbar">
+              {prompts.map((prompt, i) => {
+                const isAllDone = !isRunning && currentIndex === prompts.length;
+                const isDone = isAllDone ? true : i < currentIndex;
+                const isActive = isRunning && i === currentIndex;
+                const isPending = !isDone && !isActive;
+
+                return (
+                  <li
+                    key={i}
+                    className={classNames(
+                      'flex items-start gap-2 px-2 py-1.5 rounded-lg text-xs',
+                      isActive ? 'bg-bolt-elements-background-depth-3 text-bolt-elements-textPrimary' : '',
+                      isDone ? 'text-bolt-elements-textTertiary line-through' : '',
+                      isPending && !isActive ? 'text-bolt-elements-textSecondary' : '',
+                    )}
+                  >
+                    <span className="mt-0.5 shrink-0">
+                      {isDone && <span className="i-ph:check-circle w-3.5 h-3.5 text-green-500" />}
+                      {isActive && <span className="i-ph:circle-notch w-3.5 h-3.5 text-blue-400 animate-spin" />}
+                      {isPending && !isActive && (
+                        <span className="i-ph:circle w-3.5 h-3.5 text-bolt-elements-textTertiary" />
+                      )}
+                    </span>
+                    <span className="truncate">{prompt}</span>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -227,15 +227,16 @@ export async function streamText(props: {
     `Model "${modelDetails.name}" is reasoning model: ${isReasoning}, using ${isReasoning ? 'maxCompletionTokens' : 'maxTokens'}: ${safeMaxTokens}`,
   );
 
-  // Validate token limits before API call
-  if (safeMaxTokens > (modelDetails.maxTokenAllowed || 128000)) {
-    logger.warn(
-      `Token limit warning: requesting ${safeMaxTokens} tokens but model supports max ${modelDetails.maxTokenAllowed || 128000}`,
-    );
+  // Clamp to model's reported max to avoid API errors / truncation warnings
+  const modelMax = modelDetails.maxTokenAllowed || 128000;
+  const clampedMaxTokens = Math.min(safeMaxTokens, modelMax);
+
+  if (clampedMaxTokens < safeMaxTokens) {
+    logger.warn(`Token limit clamped: ${safeMaxTokens} → ${clampedMaxTokens} (model max: ${modelMax})`);
   }
 
   // Use maxCompletionTokens for reasoning models (o1, GPT-5), maxTokens for traditional models
-  const tokenParams = isReasoning ? { maxCompletionTokens: safeMaxTokens } : { maxTokens: safeMaxTokens };
+  const tokenParams = isReasoning ? { maxCompletionTokens: clampedMaxTokens } : { maxTokens: clampedMaxTokens };
 
   // Filter out unsupported parameters for reasoning models
   const filteredOptions =

--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -1,6 +1,7 @@
 import { getSystemPrompt } from './prompts/prompts';
 import optimized from './prompts/optimized';
 import { getFineTunedPrompt } from './prompts/new-prompt';
+import getSlimPrompt from './prompts/slim';
 import type { DesignScheme } from '~/types/design-scheme';
 
 export interface PromptOptions {
@@ -41,6 +42,12 @@ export class PromptLibrary {
       label: 'Optimized Prompt (experimental)',
       description: 'An Experimental version of the prompt for lower token usage',
       get: (options) => optimized(options),
+    },
+    slim: {
+      label: 'Slim Prompt (local models)',
+      description:
+        'Minimal prompt for local small models (7B–13B). Strips WebContainer constraints and verbose copy — keeps only boltArtifact format and essential rules.',
+      get: (options) => getSlimPrompt(options),
     },
   };
   static getList() {

--- a/app/lib/common/prompts/slim.ts
+++ b/app/lib/common/prompts/slim.ts
@@ -1,0 +1,58 @@
+import type { PromptOptions } from '~/lib/common/prompt-library';
+import { WORK_DIR } from '~/utils/constants';
+
+/**
+ * Slim system prompt — designed for local small models (7B–13B).
+ *
+ * Strips WebContainer constraints, verbose personality copy, design-scheme
+ * instructions, and Supabase scaffolding that bloat the default prompt.
+ * Keeps only the essentials: boltArtifact format, file-write rules, and
+ * concise behavior guidance.
+ *
+ * Registered in PromptLibrary as 'slim' — selected automatically when
+ * "Slim system prompt" is enabled in the Local LLM panel.
+ */
+export default function getSlimPrompt(options: PromptOptions): string {
+  const cwd = options.cwd ?? WORK_DIR;
+
+  return `You are Bolt, a senior software developer. Write clean, correct, complete code.
+
+<hard_rules>
+  DO NOT run npm install, yarn, pnpm install, expo start, npx expo, or any dev server command.
+  DO NOT describe file changes in prose — the file does not exist until you write the boltArtifact XML.
+  DO NOT truncate file content — always write the COMPLETE file, never use "..." or "rest remains the same".
+</hard_rules>
+
+<artifact_rules>
+  Wrap ALL file changes in boltArtifact tags.
+
+  Format:
+  <boltArtifact id="unique-id" title="Short Description">
+    <boltAction type="file" filePath="path/to/file.ext">
+complete file content here — never truncated
+    </boltAction>
+  </boltArtifact>
+
+  Rules:
+  - id: lowercase-hyphenated, unique per response
+  - Write every file that needs to change, not just the first one
+  - Working directory: ${cwd}
+</artifact_rules>
+
+<thinking_rules>
+  Before writing code:
+  1. Identify which files need to change
+  2. Plan briefly, then write the artifact
+
+  Keep thinking concise — the user wants the code, not a lecture.
+</thinking_rules>
+
+<behavior_rules>
+  - Be direct. Skip preamble and lengthy explanations unless asked.
+  - Ask clarifying questions only when the task is genuinely ambiguous.
+  - One artifact per response unless multiple are clearly required.
+  - If you cannot complete a task, say so clearly and explain why.
+  - "Brief" means short prose explanations — it NEVER means writing code or file content
+    outside of a boltArtifact block. All code always goes inside boltArtifact, no exceptions.
+</behavior_rules>`;
+}

--- a/app/lib/persistence/useChatHistory.ts
+++ b/app/lib/persistence/useChatHistory.ts
@@ -215,8 +215,8 @@ ${value.content}
       try {
         await setSnapshot(db, id, snapshot);
       } catch (error) {
-        console.error('Failed to save snapshot:', error);
-        toast.error('Failed to save chat snapshot.');
+        /* Log silently — snapshot failures under resource pressure are not actionable; toasts cascade into a flood that makes the UI unusable. */
+        console.warn('Failed to save snapshot:', error);
       }
     },
     [db],

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -262,15 +262,43 @@ export class ActionRunner {
     // Pre-validate command for common issues
     const validationResult = await this.#validateShellCommand(action.content);
 
+    if (validationResult.shouldBlock) {
+      throw new ActionCommandError('Command blocked', validationResult.blockReason ?? 'Command not allowed');
+    }
+
     if (validationResult.shouldModify && validationResult.modifiedCommand) {
       logger.debug(`Modified command: ${action.content} -> ${validationResult.modifiedCommand}`);
       action.content = validationResult.modifiedCommand;
     }
 
-    const resp = await shell.executeCommand(this.runnerId.get(), action.content, () => {
+    /*
+     * Hard timeout — prevents shell commands from hanging bolt indefinitely.
+     * npm install on a large project, dev servers, or WebContainer init issues
+     * can stall forever without this. 90 s is generous for most installs;
+     * long-running dev-server commands use the 'start' action type instead.
+     */
+    const SHELL_TIMEOUT_MS = 90_000;
+
+    const execPromise = shell.executeCommand(this.runnerId.get(), action.content, () => {
       logger.debug(`[${action.type}]:Aborting Action\n\n`, action);
       action.abort();
     });
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new ActionCommandError(
+              'Shell command timed out',
+              `Command did not complete within ${SHELL_TIMEOUT_MS / 1000}s:\n${action.content}`,
+            ),
+          ),
+        SHELL_TIMEOUT_MS,
+      ),
+    );
+
+    const resp = await Promise.race([execPromise, timeoutPromise]);
+
     logger.debug(`${action.type} Shell Response: [exit code:${resp?.exitCode}]`);
 
     if (resp?.exitCode != 0) {
@@ -576,10 +604,48 @@ export class ActionRunner {
 
   async #validateShellCommand(command: string): Promise<{
     shouldModify: boolean;
+    shouldBlock?: boolean;
+    blockReason?: string;
     modifiedCommand?: string;
     warning?: string;
   }> {
     const trimmedCommand = command.trim();
+
+    /*
+     * Blocklist for commands that hang or are meaningless in WebContainer
+     * for local/native projects (React Native, Expo, etc.).
+     * Enabled via the "Block install/server commands" toggle in LocalLLMPanel.
+     */
+    const STORAGE_KEY = 'local_llm_settings';
+
+    try {
+      const saved = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+      const blockEnabled = saved ? (JSON.parse(saved).blockHangingCommands ?? false) : false;
+
+      if (blockEnabled) {
+        const BLOCKED_PATTERNS = [
+          /^(npx\s+)?expo\s+(start|run|build|publish)/i,
+          /^npm\s+(install|i|ci|run\s+start|run\s+dev|run\s+build|start)/i,
+          /^yarn(\s+(install|start|dev|build))?$/i,
+          /^pnpm\s+(install|start|dev|build)/i,
+          /^node\s+/i,
+          /^npx\s+react-native\s+(run|start|build)/i,
+        ];
+
+        for (const pattern of BLOCKED_PATTERNS) {
+          if (pattern.test(trimmedCommand)) {
+            logger.warn(`Blocked shell command (install/server blocklist): ${trimmedCommand}`);
+            return {
+              shouldModify: false,
+              shouldBlock: true,
+              blockReason: `Command blocked: "${trimmedCommand}" — install and server commands are disabled for local/native projects. Run this manually in your local terminal.`,
+            };
+          }
+        }
+      }
+    } catch {
+      /* localStorage unavailable (SSR) — skip blocklist check */
+    }
 
     // Handle rm commands that might fail due to missing files
     if (trimmedCommand.startsWith('rm ') && !trimmedCommand.includes(' -f')) {

--- a/app/lib/stores/localLLMSettings.ts
+++ b/app/lib/stores/localLLMSettings.ts
@@ -1,0 +1,125 @@
+import { map } from 'nanostores';
+import { providersStore, updateProviderSettings } from './settings';
+
+export type TokenBudget = 'off' | '20k' | '40k' | 'custom';
+
+export interface LocalLLMSettings {
+  /** Whether Ollama / LMStudio are enabled in the providers store */
+  enableLocalModels: boolean;
+  ollamaBaseUrl: string;
+  lmstudioBaseUrl: string;
+
+  /** Use the slim system prompt instead of the default */
+  slimSystemPrompt: boolean;
+
+  /** Deduplicate file writes — keep only the most-recent write per file path in context */
+  dedupFileWrites: boolean;
+
+  /** Strip prose text from older assistant messages, keeping only boltArtifact blocks */
+  stripOldProse: boolean;
+
+  /** Disable bolt's context-file-selection pass (recommended for local models) */
+  disableContextOptimization: boolean;
+
+  /** Estimated token budget for message-history pruning */
+  tokenBudget: TokenBudget;
+
+  /** Used when tokenBudget === 'custom' */
+  tokenBudgetCustom: number;
+
+  /** Use a 3-minute stream timeout instead of 45 s — needed for local models with slow TTFT */
+  extendedStreamTimeout: boolean;
+
+  /** Block npm install, expo start, and other commands that hang in WebContainer */
+  blockHangingCommands: boolean;
+}
+
+const STORAGE_KEY = 'local_llm_settings';
+const isBrowser = typeof window !== 'undefined';
+
+export const LOCAL_LLM_DEFAULTS: LocalLLMSettings = {
+  enableLocalModels: false,
+  ollamaBaseUrl: 'http://localhost:11434',
+  lmstudioBaseUrl: 'http://localhost:1234',
+  slimSystemPrompt: false,
+  dedupFileWrites: false,
+  stripOldProse: false,
+  disableContextOptimization: true,
+  tokenBudget: 'off',
+  tokenBudgetCustom: 32000,
+  extendedStreamTimeout: true,
+  blockHangingCommands: true,
+};
+
+function loadSettings(): LocalLLMSettings {
+  if (!isBrowser) {
+    return LOCAL_LLM_DEFAULTS;
+  }
+
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? { ...LOCAL_LLM_DEFAULTS, ...JSON.parse(saved) } : LOCAL_LLM_DEFAULTS;
+  } catch {
+    return LOCAL_LLM_DEFAULTS;
+  }
+}
+
+export const localLLMSettingsStore = map<LocalLLMSettings>(loadSettings());
+
+export function updateLocalLLMSettings(patch: Partial<LocalLLMSettings>) {
+  const current = localLLMSettingsStore.get();
+  const next = { ...current, ...patch };
+  localLLMSettingsStore.set(next);
+
+  if (isBrowser) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  }
+
+  /*
+   * Only sync provider_settings when the user explicitly changes the enable
+   * flag or URLs — never on passive reads or other setting changes.
+   * This prevents clobbering the user's existing provider config on init.
+   */
+  if ('enableLocalModels' in patch || 'ollamaBaseUrl' in patch || 'lmstudioBaseUrl' in patch) {
+    syncProvidersStore(next);
+  }
+}
+
+function syncProvidersStore(settings: LocalLLMSettings) {
+  const currentProviders = providersStore.get();
+
+  if (currentProviders.Ollama) {
+    updateProviderSettings('Ollama', {
+      ...currentProviders.Ollama.settings,
+      enabled: settings.enableLocalModels,
+      baseUrl: settings.ollamaBaseUrl,
+    } as any);
+  }
+
+  if (currentProviders.LMStudio) {
+    updateProviderSettings('LMStudio', {
+      ...currentProviders.LMStudio.settings,
+      enabled: settings.enableLocalModels,
+      baseUrl: settings.lmstudioBaseUrl,
+    } as any);
+  }
+}
+
+/** Returns the numeric token budget, or null if budgeting is off. */
+export function getTokenBudget(settings: LocalLLMSettings): number | null {
+  switch (settings.tokenBudget) {
+    case '20k':
+      return 20_000;
+    case '40k':
+      return 40_000;
+    case 'custom':
+      return settings.tokenBudgetCustom > 0 ? settings.tokenBudgetCustom : null;
+    default:
+      return null;
+  }
+}
+
+/** Rough token estimator: ~4 chars per token */
+export function estimateTokens(content: string): number {
+  return Math.ceil(content.length / 4);
+}

--- a/app/lib/stores/promptQueue.ts
+++ b/app/lib/stores/promptQueue.ts
@@ -1,0 +1,107 @@
+import { map } from 'nanostores';
+
+export interface PromptQueueState {
+  prompts: string[];
+  currentIndex: number;
+  isRunning: boolean;
+  pendingPrompt: string | null;
+}
+
+export const promptQueueStore = map<PromptQueueState>({
+  prompts: [],
+  currentIndex: 0,
+  isRunning: false,
+  pendingPrompt: null,
+});
+
+/** Load a fresh list of prompts (replaces any existing queue). */
+export function loadQueue(prompts: string[]) {
+  promptQueueStore.set({
+    prompts,
+    currentIndex: 0,
+    isRunning: false,
+    pendingPrompt: null,
+  });
+}
+
+/** Start the queue from the beginning and fire the first prompt. */
+export function startQueue() {
+  const { prompts } = promptQueueStore.get();
+
+  if (prompts.length === 0) {
+    return;
+  }
+
+  promptQueueStore.set({
+    prompts,
+    currentIndex: 0,
+    isRunning: true,
+    pendingPrompt: prompts[0],
+  });
+}
+
+/** Stop the queue without clearing the prompt list or resetting the index. */
+export function stopQueue() {
+  promptQueueStore.setKey('isRunning', false);
+  promptQueueStore.setKey('pendingPrompt', null);
+}
+
+/**
+ * Resume a paused queue from the current index.
+ * No-op if already running or if there are no remaining prompts.
+ */
+export function resumeQueue() {
+  const { prompts, currentIndex, isRunning } = promptQueueStore.get();
+
+  if (isRunning || currentIndex >= prompts.length) {
+    return;
+  }
+
+  promptQueueStore.set({
+    prompts,
+    currentIndex,
+    isRunning: true,
+    pendingPrompt: prompts[currentIndex],
+  });
+}
+
+/** Clear the queue entirely and reset all state. */
+export function clearQueue() {
+  promptQueueStore.set({
+    prompts: [],
+    currentIndex: 0,
+    isRunning: false,
+    pendingPrompt: null,
+  });
+}
+
+/**
+ * Called by ChatImpl after onFinish fires.
+ * Advances to the next prompt or marks the queue done.
+ * Returns the next prompt string, or null if the queue is finished.
+ */
+export function advanceQueue(): string | null {
+  const { prompts, currentIndex, isRunning } = promptQueueStore.get();
+
+  if (!isRunning) {
+    return null;
+  }
+
+  const next = currentIndex + 1;
+
+  if (next >= prompts.length) {
+    /* Keep currentIndex at prompts.length so the UI shows all items as done */
+    promptQueueStore.set({ prompts, currentIndex: prompts.length, isRunning: false, pendingPrompt: null });
+    return null;
+  }
+
+  promptQueueStore.setKey('currentIndex', next);
+  promptQueueStore.setKey('pendingPrompt', prompts[next]);
+
+  return prompts[next];
+}
+
+/** Clear pending after ChatImpl has consumed it. */
+export function clearPendingPrompt() {
+  promptQueueStore.setKey('pendingPrompt', null);
+}

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -40,32 +40,49 @@ function parseCookies(cookieHeader: string): Record<string, string> {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
+  const {
+    messages,
+    files,
+    promptId,
+    contextOptimization,
+    supabase,
+    chatMode,
+    designScheme,
+    maxLLMSteps,
+    isLocalModel,
+  } = await request.json<{
+    messages: Messages;
+    files: any;
+    promptId?: string;
+    contextOptimization: boolean;
+    chatMode: 'discuss' | 'build';
+    designScheme?: DesignScheme;
+    supabase?: {
+      isConnected: boolean;
+      hasSelectedProject: boolean;
+      credentials?: {
+        anonKey?: string;
+        supabaseUrl?: string;
+      };
+    };
+    maxLLMSteps: number;
+
+    /** True when routing to a local model (Ollama / LMStudio) — uses a longer stream timeout */
+    isLocalModel?: boolean;
+  }>();
+
+  /*
+   * Local models (Ollama / LMStudio) can take 60–90 s before the first token
+   * arrives while the model loads context. Cloud APIs are fast so 45 s is fine.
+   * The timeout resets on every token, so this only affects pre-generation silence.
+   */
   const streamRecovery = new StreamRecoveryManager({
-    timeout: 45000,
+    timeout: isLocalModel ? 180000 : 45000,
     maxRetries: 2,
     onTimeout: () => {
       logger.warn('Stream timeout - attempting recovery');
     },
   });
-
-  const { messages, files, promptId, contextOptimization, supabase, chatMode, designScheme, maxLLMSteps } =
-    await request.json<{
-      messages: Messages;
-      files: any;
-      promptId?: string;
-      contextOptimization: boolean;
-      chatMode: 'discuss' | 'build';
-      designScheme?: DesignScheme;
-      supabase?: {
-        isConnected: boolean;
-        hasSelectedProject: boolean;
-        credentials?: {
-          anonKey?: string;
-          supabaseUrl?: string;
-        };
-      };
-      maxLLMSteps: number;
-    }>();
 
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
@@ -115,38 +132,70 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
             message: 'Analysing Request',
           } satisfies ProgressAnnotation);
 
+          /*
+           * Wrap both LLM pre-passes in a timeout so local models (Ollama / LMStudio)
+           * degrade gracefully instead of hanging the stream.
+           *
+           * - isLocalModel=true  → 45 s timeout, falls back to keyword-based selection
+           * - isLocalModel=false → 120 s timeout (cloud APIs are fast, but still capped)
+           *
+           * Keyword fallback: scan the latest user message for file-path fragments and
+           * component/function names, then include only files whose paths contain a match.
+           * No extra LLM call needed.
+           */
+          const CONTEXT_TIMEOUT_MS = isLocalModel ? 45_000 : 120_000;
+
+          const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T | null> =>
+            Promise.race([
+              promise,
+              new Promise<null>((resolve) =>
+                setTimeout(() => {
+                  logger.warn(`${label} timed out after ${ms}ms — falling back`);
+                  resolve(null);
+                }, ms),
+              ),
+            ]);
+
           // Create a summary of the chat
           console.log(`Messages count: ${processedMessages.length}`);
 
-          summary = await createSummary({
-            messages: [...processedMessages],
-            env: context.cloudflare?.env,
-            apiKeys,
-            providerSettings,
-            promptId,
-            contextOptimization,
-            onFinish(resp) {
-              if (resp.usage) {
-                logger.debug('createSummary token usage', JSON.stringify(resp.usage));
-                cumulativeUsage.completionTokens += resp.usage.completionTokens || 0;
-                cumulativeUsage.promptTokens += resp.usage.promptTokens || 0;
-                cumulativeUsage.totalTokens += resp.usage.totalTokens || 0;
-              }
-            },
-          });
+          const summaryResult = await withTimeout(
+            createSummary({
+              messages: [...processedMessages],
+              env: context.cloudflare?.env,
+              apiKeys,
+              providerSettings,
+              promptId,
+              contextOptimization,
+              onFinish(resp) {
+                if (resp.usage) {
+                  logger.debug('createSummary token usage', JSON.stringify(resp.usage));
+                  cumulativeUsage.completionTokens += resp.usage.completionTokens || 0;
+                  cumulativeUsage.promptTokens += resp.usage.promptTokens || 0;
+                  cumulativeUsage.totalTokens += resp.usage.totalTokens || 0;
+                }
+              },
+            }),
+            CONTEXT_TIMEOUT_MS,
+            'createSummary',
+          );
+          summary = summaryResult ?? undefined;
+
           dataStream.writeData({
             type: 'progress',
             label: 'summary',
             status: 'complete',
             order: progressCounter++,
-            message: 'Analysis Complete',
+            message: summary ? 'Analysis Complete' : 'Analysis skipped (timeout)',
           } satisfies ProgressAnnotation);
 
-          dataStream.writeMessageAnnotation({
-            type: 'chatSummary',
-            summary,
-            chatId: processedMessages.slice(-1)?.[0]?.id,
-          } as ContextAnnotation);
+          if (summary) {
+            dataStream.writeMessageAnnotation({
+              type: 'chatSummary',
+              summary,
+              chatId: processedMessages.slice(-1)?.[0]?.id,
+            } as ContextAnnotation);
+          }
 
           // Update context buffer
           logger.debug('Updating Context Buffer');
@@ -160,24 +209,69 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
           // Select context files
           console.log(`Messages count: ${processedMessages.length}`);
-          filteredFiles = await selectContext({
-            messages: [...processedMessages],
-            env: context.cloudflare?.env,
-            apiKeys,
-            files,
-            providerSettings,
-            promptId,
-            contextOptimization,
-            summary,
-            onFinish(resp) {
-              if (resp.usage) {
-                logger.debug('selectContext token usage', JSON.stringify(resp.usage));
-                cumulativeUsage.completionTokens += resp.usage.completionTokens || 0;
-                cumulativeUsage.promptTokens += resp.usage.promptTokens || 0;
-                cumulativeUsage.totalTokens += resp.usage.totalTokens || 0;
-              }
-            },
-          });
+
+          if (summary) {
+            // Full LLM-based context selection
+            const selectResult = await withTimeout(
+              selectContext({
+                messages: [...processedMessages],
+                env: context.cloudflare?.env,
+                apiKeys,
+                files,
+                providerSettings,
+                promptId,
+                contextOptimization,
+                summary,
+                onFinish(resp) {
+                  if (resp.usage) {
+                    logger.debug('selectContext token usage', JSON.stringify(resp.usage));
+                    cumulativeUsage.completionTokens += resp.usage.completionTokens || 0;
+                    cumulativeUsage.promptTokens += resp.usage.promptTokens || 0;
+                    cumulativeUsage.totalTokens += resp.usage.totalTokens || 0;
+                  }
+                },
+              }),
+              CONTEXT_TIMEOUT_MS,
+              'selectContext',
+            );
+            filteredFiles = selectResult ?? undefined;
+          }
+
+          /*
+           * Keyword fallback — used when the LLM pre-pass timed out or returned nothing.
+           * Extracts terms from the latest user message and matches against file paths.
+           * Always includes files that are short/critical (package.json, app entry points).
+           */
+          if (!filteredFiles && files) {
+            logger.debug('Using keyword fallback for context selection');
+
+            const lastUserMsg = [...processedMessages].reverse().find((m) => m.role === 'user');
+            const msgText = typeof lastUserMsg?.content === 'string' ? lastUserMsg.content.toLowerCase() : '';
+
+            // Extract candidate keywords: path-like tokens and CamelCase identifiers
+            const keywords = [
+              ...(msgText.match(/[\w/-]+\.\w+/g) ?? []), // file.ext patterns
+              ...(msgText.match(/[A-Z][a-zA-Z]{2,}/g) ?? []), // ComponentNames
+              ...(msgText.match(/\b(app|index|main|screen|hook|util|type|context|store|nav)\w*/gi) ?? []),
+            ].map((k) => k.toLowerCase());
+
+            const ALWAYS_INCLUDE = ['package.json', 'app.json', 'app.tsx', 'app.jsx', 'index.tsx', 'index.js'];
+
+            filteredFiles = Object.fromEntries(
+              Object.entries(files).filter(([path]) => {
+                const lpath = path.toLowerCase();
+                return (
+                  ALWAYS_INCLUDE.some((f) => lpath.endsWith(f)) ||
+                  keywords.some((kw) => kw.length > 3 && lpath.includes(kw))
+                );
+              }),
+            ) as FileMap;
+
+            // If nothing matched at all, include everything (safe fallback)
+            if (Object.keys(filteredFiles).length === 0) {
+              filteredFiles = undefined;
+            }
+          }
 
           if (filteredFiles) {
             logger.debug(`files in context : ${JSON.stringify(Object.keys(filteredFiles))}`);
@@ -185,7 +279,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
           dataStream.writeMessageAnnotation({
             type: 'codeContext',
-            files: Object.keys(filteredFiles).map((key) => {
+            files: Object.keys(filteredFiles ?? {}).map((key) => {
               let path = key;
 
               if (path.startsWith(WORK_DIR)) {

--- a/app/utils/zipImport.ts
+++ b/app/utils/zipImport.ts
@@ -1,0 +1,234 @@
+import type { Message } from 'ai';
+import JSZip from 'jszip';
+import { generateId, shouldIncludeFile } from './fileUtils';
+import { escapeBoltTags } from './projectCommands';
+
+/**
+ * Checks whether a Uint8Array looks like a binary file.
+ * Mirrors the logic in isBinaryFile (fileUtils.ts) but works directly
+ * with raw bytes instead of a browser File object.
+ */
+function isBinaryBuffer(buffer: Uint8Array): boolean {
+  const checkLength = Math.min(buffer.length, 1024);
+
+  for (let i = 0; i < checkLength; i++) {
+    const byte = buffer[i];
+
+    if (byte === 0 || (byte < 32 && byte !== 9 && byte !== 10 && byte !== 13)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Detects and returns a common root prefix that all file paths share
+ * (e.g. "my-project/" when macOS Compress or GitHub wraps everything
+ * in a top-level folder). Returns an empty string if there is no such
+ * prefix, or if the prefix would consume all path segments.
+ */
+function detectRootPrefix(paths: string[]): string {
+  if (paths.length === 0) {
+    return '';
+  }
+
+  const firstSegment = paths[0].split('/')[0] + '/';
+  const allSharePrefix = paths.every((p) => p.startsWith(firstSegment));
+
+  // Make sure the prefix is not the entire path of every file
+  const prefixIsWholeFile = paths.every((p) => p === firstSegment || p === firstSegment.slice(0, -1));
+
+  if (allSharePrefix && !prefixIsWholeFile && firstSegment !== '/') {
+    return firstSegment;
+  }
+
+  return '';
+}
+
+export interface ZipImportResult {
+  messages: Message[];
+  skippedBinary: number;
+  skippedIgnored: number;
+  totalFiles: number;
+  hasPackageJson: boolean;
+  hasExpoConfig: boolean;
+  fileTreeSummary: string;
+
+  /** Contents of .bolt/prompt if present in the ZIP — used as the auto-fill first message */
+  boltPrompt: string | null;
+}
+
+/**
+ * Builds a compact file tree string from a list of file paths.
+ * Used to replace the full artifact content in context after import.
+ */
+export function buildFileTreeSummary(paths: string[]): string {
+  return [...paths]
+    .sort()
+    .map((p) => `  ${p}`)
+    .join('\n');
+}
+
+/**
+ * Reads a ZIP file and converts its contents into the same boltArtifact
+ * chat-message structure that createChatFromFolder produces. This lets
+ * bolt load the project correctly without writing directly to the
+ * WebContainer filesystem (which can be wiped by navigation resets).
+ */
+export const createChatFromZip = async (zipFile: File): Promise<ZipImportResult> => {
+  const zip = new JSZip();
+  const contents = await zip.loadAsync(zipFile);
+
+  // Collect all non-directory entries
+  const allEntries = Object.entries(contents.files).filter(([, entry]) => !entry.dir);
+
+  if (allEntries.length === 0) {
+    throw new Error('The ZIP file contains no files.');
+  }
+
+  // Strip common root prefix (e.g. "my-project/" from macOS Compress)
+  const rawPaths = allEntries.map(([path]) => path);
+  const prefix = detectRootPrefix(rawPaths);
+
+  // Process every entry: resolve path, filter, read bytes
+  const fileArtifacts: Array<{ path: string; content: string }> = [];
+  const binaryFilePaths: string[] = [];
+  let skippedIgnored = 0;
+
+  for (const [rawPath, zipEntry] of allEntries) {
+    const relativePath = prefix ? rawPath.slice(prefix.length) : rawPath;
+
+    // Skip empty paths that arise when stripping the prefix of the root dir entry itself
+    if (!relativePath) {
+      continue;
+    }
+
+    // Apply the same ignore rules as ImportFolderButton
+    if (!shouldIncludeFile(relativePath)) {
+      skippedIgnored++;
+      continue;
+    }
+
+    const buffer = await zipEntry.async('uint8array');
+
+    if (isBinaryBuffer(buffer)) {
+      binaryFilePaths.push(relativePath);
+      continue;
+    }
+
+    const content = new TextDecoder('utf-8', { fatal: false }).decode(buffer);
+    fileArtifacts.push({ path: relativePath, content });
+  }
+
+  if (fileArtifacts.length === 0) {
+    throw new Error('No readable text files found in the ZIP (all files were binary or ignored).');
+  }
+
+  /*
+   * Check for a .bolt/prompt file — its contents become the auto-fill first message,
+   * overriding the default "install deps" / Expo review prompts.
+   * The file is intentionally NOT included in the boltArtifact so bolt doesn't
+   * try to write it into the WebContainer filesystem.
+   */
+  const boltPromptIndex = fileArtifacts.findIndex((f) => f.path === '.bolt/prompt' || f.path === 'bolt/prompt');
+  let boltPrompt: string | null = null;
+
+  if (boltPromptIndex !== -1) {
+    boltPrompt = fileArtifacts[boltPromptIndex].content.trim() || null;
+    fileArtifacts.splice(boltPromptIndex, 1); // Don't send this file to the WebContainer
+  }
+
+  // Detect whether this is a Node project so we can craft the follow-up prompt
+  const hasPackageJson = fileArtifacts.some((f) => f.path === 'package.json' || f.path.endsWith('/package.json'));
+
+  /*
+   * Detect Expo/React Native projects so we can suppress the "npm install
+   * and start dev server" prompt — WebContainer can't run native mobile code.
+   * We check for app.json / app.config.js (Expo-specific config files) or
+   * an "expo" key in the package.json dependencies.
+   */
+  const hasExpoConfig =
+    fileArtifacts.some((f) => f.path === 'app.json' || f.path === 'app.config.js' || f.path === 'app.config.ts') ||
+    fileArtifacts.some((f) => {
+      if (f.path !== 'package.json') {
+        return false;
+      }
+
+      try {
+        const pkg = JSON.parse(f.content);
+        return !!(pkg.dependencies?.expo || pkg.devDependencies?.expo);
+      } catch {
+        return false;
+      }
+    });
+
+  /*
+   * For Expo projects, strip the scripts from package.json so bolt has
+   * nothing to execute even if it tries. The user will run the project
+   * locally with Expo CLI. We preserve the rest of package.json intact.
+   */
+  if (hasExpoConfig) {
+    const pkgIndex = fileArtifacts.findIndex((f) => f.path === 'package.json');
+
+    if (pkgIndex !== -1) {
+      try {
+        const pkg = JSON.parse(fileArtifacts[pkgIndex].content);
+        pkg.scripts = {
+          _note: 'Run this project locally: npx expo start',
+        };
+        fileArtifacts[pkgIndex] = {
+          ...fileArtifacts[pkgIndex],
+          content: JSON.stringify(pkg, null, 2),
+        };
+      } catch {
+        /* If package.json is unparseable, leave it as-is */
+      }
+    }
+  }
+
+  const fileTreeSummary = buildFileTreeSummary(fileArtifacts.map((f) => f.path));
+  const folderName = zipFile.name.replace(/\.zip$/i, '');
+
+  const binaryFilesMessage =
+    binaryFilePaths.length > 0
+      ? `\n\nSkipped ${binaryFilePaths.length} binary file${binaryFilePaths.length === 1 ? '' : 's'}:\n${binaryFilePaths.map((f) => `- ${f}`).join('\n')}`
+      : '';
+
+  const filesMessage: Message = {
+    role: 'assistant',
+    content: `I've imported the contents of the "${folderName}" ZIP archive.${binaryFilesMessage}
+
+<boltArtifact id="imported-files" title="Imported Files" type="bundled">
+${fileArtifacts
+  .map(
+    (file) => `<boltAction type="file" filePath="${file.path}">
+${escapeBoltTags(file.content)}
+</boltAction>`,
+  )
+  .join('\n\n')}
+</boltArtifact>`,
+    id: generateId(),
+    createdAt: new Date(),
+  };
+
+  const userMessage: Message = {
+    role: 'user',
+    id: generateId(),
+    content: `Import the "${folderName}" project from ZIP`,
+    createdAt: new Date(),
+  };
+
+  const messages: Message[] = [userMessage, filesMessage];
+
+  return {
+    messages,
+    skippedBinary: binaryFilePaths.length,
+    skippedIgnored,
+    totalFiles: fileArtifacts.length + binaryFilePaths.length + skippedIgnored,
+    hasPackageJson,
+    hasExpoConfig,
+    fileTreeSummary,
+    boltPrompt,
+  };
+};


### PR DESCRIPTION
Adds a complete workflow for running local small models (Qwen, Mistral, etc.) through multi-step project builds without browser lock-up or WebContainer overwhelm. Validated end-to-end with Qwen 2.5-coder:7b via Ollama against a 21-prompt React Native / Expo build queue.

## Local LLM Settings Panel (new: LocalLLMPanel)
- Per-session toggles: extended stream timeout (3 min vs 45 s), shell command blocking, slim system prompt, dedup file writes, strip old prose, token budget
- Persisted to localStorage via nanostores map (localLLMSettingsStore)
- Flyout panel anchored above the chat input bar with dynamic max-height

## Prompt Queue (PromptQueuePanel)
- Run N queued prompts end-to-end unattended; live progress bar
- Adaptive delay between prompts: polls action-runner until all file writes / shell commands reach a terminal state before firing the next prompt — prevents WebContainer being overwhelmed by rapid-fire writes
- Paste or load prompts from a newline-delimited text file

## Shell Safety (action-runner)
- Blocklist for hanging commands: expo start, npm install, yarn, pnpm, node, react-native run — throws before execution with a clear message
- 90-second hard timeout on any shell action via Promise.race()
- Toggle via blockHangingCommands setting

## Stream + Context Optimisations (api.chat)
- Extended stream timeout: 180 000 ms for local models (isLocalModel flag)
- Context optimisation re-enabled for local models with graceful fallback: LLM pre-pass wrapped in withTimeout(); keyword matching fallback on timeout
- Token limit clamped to model's reported max (fixes Qwen 8 000 token warning)

## Main-Thread Performance (Chat.client)
- 4 sequential setMessages() calls in onFinish collapsed into one, wrapped in startTransition() — eliminates "Page Unresponsive" dialogs during queues
- storeMessageHistory deferred to requestIdleCallback (setTimeout fallback) so IndexedDB writes never block the render thread
- Resource-exhaustion errors (ERR_INSUFFICIENT_RESOURCES, Failed to fetch) demoted from toast flood to console.warn

## Slim Prompt (prompts/slim)
- Minimal system prompt for 7B–13B models; hard_rules block first with DO NOT run install/server commands, DO NOT truncate files, DO NOT emit code outside boltArtifact — then concise format and behaviour rules
- Registered in PromptLibrary as "Slim Prompt (local models)"

## Artifact Render-Loop Fix
- computed() store moved from inline JSX into useRef — fixes "Maximum update depth exceeded" on every workbenchStore update

## ZIP Import (.bolt/prompt)
- Detects .bolt/prompt inside imported ZIPs; surfaces content as the auto-fill textarea value so projects can ship a first-message template

## Misc
- useChatHistory snapshot save failure: toast → console.warn
- Token limit clamped in stream-text.ts (model.maxTokenAllowed guard)

#####

## Summary

Adds a complete, validated workflow for running local small models (Qwen, Mistral, etc.) through multi-step project builds without browser lock-up or WebContainer overwhelm. Tested end-to-end with **Qwen 2.5-coder:7b via Ollama** against a 21-prompt React Native / Expo build queue — clean completion, responsive UI throughout.

### What's included

**Local LLM Settings Panel** (`LocalLLMPanel`) — new flyout above the chat input with per-session toggles: extended stream timeout, shell command blocking, slim system prompt, dedup file writes, strip old prose, token budget. All persisted to localStorage.

**Prompt Queue** (`PromptQueuePanel`) — paste or load N prompts, run them unattended with a live progress bar. Uses adaptive delay between prompts: polls the action-runner until all file writes/shell commands reach a terminal state before firing the next one, preventing WebContainer overwhelm.

**Shell safety** — blocklist in `action-runner.ts` for commands that hang WebContainer (`expo start`, `npm install`, `yarn`, `pnpm`, `node`, `react-native run`). 90-second hard timeout on all shell actions. Toggle in the settings panel.

**Stream + context optimisations** — 180 s stream timeout for local models; context optimisation re-enabled for local models with timeout wrapper + keyword-matching fallback; token limit clamped to model's reported max (fixes Qwen 8 000 token warning).

**Main-thread performance** — 4 sequential `setMessages()` calls in `onFinish` collapsed into one `startTransition()`-wrapped call, eliminating "Page Unresponsive" dialogs during long queues. `storeMessageHistory` deferred to `requestIdleCallback` so IndexedDB writes never block rendering.

**Slim prompt** — minimal system prompt for 7B–13B models with `hard_rules` block first. Registered in `PromptLibrary` as "Slim Prompt (local models)".

**Artifact render-loop fix** — `computed()` store moved from inline JSX to `useRef`, fixing "Maximum update depth exceeded" on every `workbenchStore` update.

**ZIP import `.bolt/prompt`** — detects a `.bolt/prompt` file inside imported ZIPs and surfaces its content as the auto-fill textarea value, letting projects ship their own first-message template.

## Test plan

- [ ] Enable Ollama in provider settings, load a local model
- [ ] Open Local LLM panel — verify all toggles persist across page reload
- [ ] Import a ZIP with a `.bolt/prompt` file — textarea should pre-fill
- [ ] Queue 5+ prompts via PromptQueuePanel, run to completion — UI stays responsive
- [ ] Verify shell commands like `npm install` are blocked with a clear error message
- [ ] Send a chat with a non-local provider — verify nothing regressed