### PR TITLE
feat: add FuturMix as AI model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,18 @@ CEREBRAS_API_KEY=your_cerebras_api_key_here
 # Get your API key from: https://fireworks.ai/api-keys
 FIREWORKS_API_KEY=your_fireworks_api_key_here
 
+# FuturMix (Unified AI Gateway with 22+ models)
+# Get your API key from: https://futurmix.ai
+FUTURMIX_API_KEY=your_futurmix_api_key_here
+
 # OpenAI GPT models
 # Get your API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
 # GitHub Models (OpenAI models hosted by GitHub)
 # Get your Personal Access Token from: https://github.com/settings/tokens
-# - Select "Fine-grained tokens" 
-# - Set repository access to "All repositories" 
+# - Select "Fine-grained tokens"
+# - Set repository access to "All repositories"
 # - Enable "GitHub Models" permission
 GITHUB_API_KEY=github_pat_your_personal_access_token_here
 

--- a/app/lib/modules/llm/providers/futurmix.ts
+++ b/app/lib/modules/llm/providers/futurmix.ts
@@ -1,0 +1,145 @@
+import { BaseProvider, getOpenAILikeModel } from '~/lib/modules/llm/base-provider';
+import type { ModelInfo } from '~/lib/modules/llm/types';
+import type { IProviderSetting } from '~/types/model';
+import type { LanguageModelV1 } from 'ai';
+
+interface FuturMixModel {
+  id: string;
+  object: string;
+  created: number;
+  owned_by: string;
+}
+
+interface FuturMixModelsResponse {
+  object: string;
+  data: FuturMixModel[];
+}
+
+export default class FuturMixProvider extends BaseProvider {
+  name = 'FuturMix';
+  getApiKeyLink = 'https://futurmix.ai';
+
+  config = {
+    apiTokenKey: 'FUTURMIX_API_KEY',
+    baseUrl: 'https://futurmix.ai/v1',
+  };
+
+  staticModels: ModelInfo[] = [
+    {
+      name: 'claude-4-opus-20250514',
+      label: 'Claude 4 Opus',
+      provider: 'FuturMix',
+      maxTokenAllowed: 200000,
+    },
+    {
+      name: 'claude-sonnet-4-5-20250929',
+      label: 'Claude Sonnet 4.5',
+      provider: 'FuturMix',
+      maxTokenAllowed: 200000,
+    },
+    {
+      name: 'gpt-4o',
+      label: 'GPT-4o',
+      provider: 'FuturMix',
+      maxTokenAllowed: 128000,
+    },
+    {
+      name: 'gpt-4o-mini',
+      label: 'GPT-4o Mini',
+      provider: 'FuturMix',
+      maxTokenAllowed: 128000,
+    },
+    {
+      name: 'gemini-2.5-pro-exp-03-25',
+      label: 'Gemini 2.5 Pro',
+      provider: 'FuturMix',
+      maxTokenAllowed: 2097152,
+    },
+    {
+      name: 'gemini-2.5-flash-exp-03-25',
+      label: 'Gemini 2.5 Flash',
+      provider: 'FuturMix',
+      maxTokenAllowed: 1048576,
+    },
+    {
+      name: 'deepseek-chat',
+      label: 'DeepSeek Chat',
+      provider: 'FuturMix',
+      maxTokenAllowed: 64000,
+    },
+  ];
+
+  async getDynamicModels(
+    apiKeys?: Record<string, string>,
+    settings?: IProviderSetting,
+    serverEnv?: Record<string, string>,
+  ): Promise<ModelInfo[]> {
+    const { baseUrl, apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: settings,
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: '',
+      defaultApiTokenKey: 'FUTURMIX_API_KEY',
+    });
+
+    if (!apiKey) {
+      return [];
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}/models`, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        signal: this.createTimeoutSignal(5000),
+      });
+
+      if (!response.ok) {
+        console.error(`FuturMix API error: ${response.statusText}`);
+        return [];
+      }
+
+      const data = (await response.json()) as FuturMixModelsResponse;
+      const staticModelIds = this.staticModels.map((m) => m.name);
+
+      // Filter out models we already have in staticModels
+      const dynamicModels =
+        data.data
+          ?.filter((model: any) => !staticModelIds.includes(model.id))
+          .map((m: any) => ({
+            name: m.id,
+            label: `${m.id} (Dynamic)`,
+            provider: this.name,
+            maxTokenAllowed: 128000, // Default context window
+          })) || [];
+
+      return dynamicModels;
+    } catch (error) {
+      console.error(`Failed to fetch FuturMix models:`, error);
+      return [];
+    }
+  }
+
+  getModelInstance(options: {
+    model: string;
+    serverEnv: Env;
+    apiKeys?: Record<string, string>;
+    providerSettings?: Record<string, IProviderSetting>;
+  }): LanguageModelV1 {
+    const { model, serverEnv, apiKeys, providerSettings } = options;
+
+    const { baseUrl, apiKey } = this.getProviderBaseUrlAndKey({
+      apiKeys,
+      providerSettings: providerSettings?.[this.name],
+      serverEnv: serverEnv as any,
+      defaultBaseUrlKey: '',
+      defaultApiTokenKey: 'FUTURMIX_API_KEY',
+    });
+
+    if (!apiKey) {
+      throw new Error(`Missing API key for ${this.name} provider`);
+    }
+
+    return getOpenAILikeModel(baseUrl!, apiKey, model);
+  }
+}

--- a/app/lib/modules/llm/registry.ts
+++ b/app/lib/modules/llm/registry.ts
@@ -3,6 +3,7 @@ import CerebrasProvider from './providers/cerebras';
 import CohereProvider from './providers/cohere';
 import DeepseekProvider from './providers/deepseek';
 import FireworksProvider from './providers/fireworks';
+import FuturMixProvider from './providers/futurmix';
 import GoogleProvider from './providers/google';
 import GroqProvider from './providers/groq';
 import HuggingFaceProvider from './providers/huggingface';
@@ -27,6 +28,7 @@ export {
   CohereProvider,
   DeepseekProvider,
   FireworksProvider,
+  FuturMixProvider,
   GoogleProvider,
   GroqProvider,
   HuggingFaceProvider,


### PR DESCRIPTION
## Summary

Add FuturMix as a new AI provider in bolt.diy. FuturMix is a multi-model AI API hub providing 22+ models .

## Changes

- Add `app/lib/modules/llm/providers/futurmix.ts` — Provider implementation
- Update `app/lib/modules/llm/registry.ts` — Register provider
- Update `.env.example` — Add `FUTURMIX_API_KEY` variable

## Features

- Static models: Claude 4 Opus, Claude Sonnet 4.5, GPT-4o, Gemini 2.5 Pro/Flash, DeepSeek
- Dynamic model discovery via `/v1/models` endpoint
- Uses `getOpenAILikeModel()` for OpenAI compatibility
- 99.99% SLA with auto-failover

## Configuration

Set `FUTURMIX_API_KEY` in environment or enter in the UI provider settings.

## Test Plan

- [ ] Provider appears in model selector
- [ ] Models load correctly (static + dynamic)
- [ ] Chat completions work with FuturMix API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

