### PR TITLE
fix: count only non-comment lines in command-sequence detection

### DIFF
--- a/app/lib/runtime/enhanced-message-parser.ts
+++ b/app/lib/runtime/enhanced-message-parser.ts
@@ -405,14 +405,19 @@ ${content.trim()}
   }
 
   private _isCommandSequence(lines: string[]): boolean {
-    // If most lines look like individual commands, treat as command sequence
-    const commandLikeLines = lines.filter(
-      (line) =>
-        line.length > 0 && !line.startsWith('#') && (this._isSingleLineCommand(line) || this._isSimpleCommand(line)),
+    // Only consider non-comment, non-empty lines when computing the ratio.
+    const nonCommentLines = lines.filter((line) => line.length > 0 && !line.startsWith('#'));
+
+    if (nonCommentLines.length === 0) {
+      return false;
+    }
+
+    const commandLikeLines = nonCommentLines.filter(
+      (line) => this._isSingleLineCommand(line) || this._isSimpleCommand(line),
     );
 
     // If more than 70% of non-comment lines are commands, treat as command sequence
-    return commandLikeLines.length / lines.length > 0.7;
+    return commandLikeLines.length / nonCommentLines.length > 0.7;
   }
 
   private _isSimpleCommand(line: string): boolean {

--- a/app/lib/runtime/message-parser.spec.ts
+++ b/app/lib/runtime/message-parser.spec.ts
@@ -185,6 +185,41 @@ describe('EnhancedStreamingMessageParser', () => {
     );
   });
 
+  it('should detect a shell command sequence even when interleaved with comments', () => {
+    const callbacks = {
+      onArtifactOpen: vi.fn(),
+      onArtifactClose: vi.fn(),
+      onActionOpen: vi.fn(),
+      onActionClose: vi.fn(),
+    };
+
+    const parser = new EnhancedStreamingMessageParser({
+      callbacks,
+    });
+
+    /*
+     * 2 of 2 non-comment lines are commands (100%); comment lines must not
+     * dilute the ratio, otherwise this is misclassified as a file to write.
+     */
+    const input = [
+      '```bash',
+      '# Install dependencies',
+      'npm install',
+      '# Start the dev server',
+      'npm run dev',
+      '```',
+    ].join('\n');
+    parser.parse('test_id', input);
+
+    expect(callbacks.onActionOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          type: 'shell',
+        }),
+      }),
+    );
+  });
+
   it('should detect file creation from code blocks with context', () => {
     const callbacks = {
       onArtifactOpen: vi.fn(),


### PR DESCRIPTION
## What
`EnhancedStreamingMessageParser._isCommandSequence` decides whether a fenced code block is a **shell command sequence** (to execute) or a **file** (to write), by what fraction of lines look like commands. The numerator already excludes comment/empty lines, but the denominator used `lines.length` (every line):

```ts
const commandLikeLines = lines.filter(
  (line) => line.length > 0 && !line.startsWith('#') && (this._isSingleLineCommand(line) || this._isSimpleCommand(line)),
);
// If more than 70% of non-comment lines are commands, treat as command sequence
return commandLikeLines.length / lines.length > 0.7;
```

The comment says "70% of **non-comment** lines", but the math divides by all lines. So comment lines dilute the ratio. A normal command snippet with explanatory comments:

````
```bash
# Install dependencies
npm install
# Start the dev server
npm run dev
```
````

is `2/2 = 100%` commands by the intended rule, but computes `2/4 = 50%`, falls below the `0.7` threshold, and is misclassified as a **file to write** instead of shell commands to **run** — the exact "code written to files instead of executed" failure this enhanced parser was built to address.

## Fix
Compute the ratio over non-comment, non-empty lines (matching the comment/intent), and guard the all-comment case against `0/0 = NaN`:

```ts
const nonCommentLines = lines.filter((line) => line.length > 0 && !line.startsWith('#'));
if (nonCommentLines.length === 0) {
  return false;
}
const commandLikeLines = nonCommentLines.filter(
  (line) => this._isSingleLineCommand(line) || this._isSimpleCommand(line),
);
return commandLikeLines.length / nonCommentLines.length > 0.7;
```

## Testing
Added a regression test to `message-parser.spec.ts` (a comment-interleaved bash block is detected as `shell`). It fails on `main` (the block isn't recognized → `onActionOpen` never fires for a `shell` action) and passes with the fix.

```
vitest run app/lib/runtime/message-parser.spec.ts
✓ 46 tests passed
```
`pnpm typecheck` and `pnpm lint` pass (pre-commit hook green).
