### PR TITLE
fix: continuation loop never stops (stream.switches is never incremented)

### DIFF
--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -75,6 +75,18 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
   const stream = new SwitchableStream();
 
+  /*
+   * FIX (2026-08-04): `stream.switches` is never incremented anywhere in this file
+   * (SwitchableStream only increments `_switches` inside `switchSource()`, which is
+   * never called here). That means the `stream.switches >= MAX_RESPONSE_SEGMENTS`
+   * safety check below never trips, and the "continue on length limit" branch can
+   * recurse forever for any model/provider that keeps returning finishReason "length"
+   * (observed in production: infinite loop, one real LLM call every ~40s, forever,
+   * silently consuming API credits). Tracking our own counter here restores the
+   * intended cap of MAX_RESPONSE_SEGMENTS.
+   */
+  let continuationSegments = 0;
+
   const cumulativeUsage = {
     completionTokens: 0,
     promptTokens: 0,
@@ -249,11 +261,16 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               return;
             }
 
-            if (stream.switches >= MAX_RESPONSE_SEGMENTS) {
+            if (continuationSegments >= MAX_RESPONSE_SEGMENTS) {
+              logger.error(
+                `Reached max token limit (${MAX_TOKENS}) and used all ${MAX_RESPONSE_SEGMENTS} continuation segments -- stopping instead of looping forever.`,
+              );
               throw Error('Cannot continue message: Maximum segments reached');
             }
 
-            const switchesLeft = MAX_RESPONSE_SEGMENTS - stream.switches;
+            continuationSegments++;
+
+            const switchesLeft = MAX_RESPONSE_SEGMENTS - continuationSegments;
 
             logger.info(`Reached max token limit (${MAX_TOKENS}): Continuing message (${switchesLeft} switches left)`);
 


### PR DESCRIPTION
## Bug

When a response is cut off by the model's token limit (`finishReason === 'length'`), `api.chat.ts` is supposed to auto-continue at most `MAX_RESPONSE_SEGMENTS` (2) times, then stop with `Cannot continue message: Maximum segments reached`.

That cap never triggers, because it checks `stream.switches`, and `SwitchableStream._switches` is only incremented inside `switchSource()` -- a method that `api.chat.ts` never calls. So `stream.switches` stays `0` forever, and the continuation branch recurses indefinitely for any model that keeps returning `finishReason: 'length'`.

## Impact

Observed in production: a long chat that grew close to the 128k context cap got stuck making one real LLM call every ~40s, forever -- 10 consecutive identical `Reached max token limit (128000): Continuing message (2 switches left)` log lines over 8 minutes, no progress, no error surfaced to the UI (it just looks frozen), and real API credits silently consumed on every retry (confirmed against a paid provider).

This isn't provider-specific -- any model/setup that legitimately hits the output token cap on a large response will loop forever instead of stopping at 2 segments as intended.

## Fix

Track continuation attempts with a local counter (`continuationSegments`) that is actually incremented on every continuation, instead of relying on the never-updated `stream.switches`. Restores the originally intended 2-segment cap.

Minimal, single-file change, no behavior change for the normal (non-looping) path.