### PR TITLE
fix: stale urlId on first save, action-runner abort race, and stuck spinner on interrupted file actions

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -5,6 +5,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 import { createHighlighter, type BundledLanguage, type BundledTheme, type HighlighterGeneric } from 'shiki';
 import type { ActionState } from '~/lib/runtime/action-runner';
 import { workbenchStore } from '~/lib/stores/workbench';
+import { streamingState } from '~/lib/stores/streaming';
 import { classNames } from '~/utils/classNames';
 import { cubicEasingFn } from '~/utils/easings';
 import { WORK_DIR } from '~/utils/constants';
@@ -194,12 +195,27 @@ export function openArtifactInWorkbench(filePath: any) {
 }
 
 const ActionList = memo(({ actions }: ActionListProps) => {
+  /*
+   * A 'file' action can end up stuck at 'pending'/'running' forever -- e.g. a
+   * response interrupted mid-file (hit a token limit, connection dropped,
+   * client crashed), which never emits the close event that would normally
+   * flip it to 'complete'. Rather than chase every code path that can leave an
+   * action in that state, guard it at render time: never show a spinner for a
+   * 'file' action once nothing is actually streaming, regardless of what its
+   * stored status says. 'start'/'shell' are excluded -- those can legitimately
+   * keep running well after the text stream ends (e.g. a real in-progress
+   * `npm install`).
+   */
+  const isStreaming = useStore(streamingState);
+
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }}>
       <ul className="list-none space-y-2.5">
         {actions.map((action, index) => {
-          const { status, type, content } = action;
+          const { type, content } = action;
           const isLast = index === actions.length - 1;
+          const isStuck = !isStreaming && type === 'file' && (action.status === 'pending' || action.status === 'running');
+          const status = isStuck ? 'aborted' : action.status;
 
           return (
             <motion.li
@@ -213,7 +229,7 @@ const ActionList = memo(({ actions }: ActionListProps) => {
               }}
             >
               <div className="flex items-center gap-1.5 text-sm">
-                <div className={classNames('text-lg', getIconColor(action.status))}>
+                <div className={classNames('text-lg', getIconColor(status))}>
                   {status === 'running' ? (
                     <>
                       {type !== 'start' ? (

--- a/app/lib/persistence/useChatHistory.ts
+++ b/app/lib/persistence/useChatHistory.ts
@@ -336,7 +336,7 @@ ${value.content}
         db,
         finalChatId, // Use the potentially updated chatId
         [...archivedMessages, ...messages],
-        urlId,
+        _urlId,
         description.get(),
         undefined,
         chatMetadata.get(),

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -107,7 +107,15 @@ export class ActionRunner {
       executed: false,
       abort: () => {
         abortController.abort();
-        this.#updateAction(actionId, { status: 'aborted' });
+
+        /*
+         * Mark executed too, not just status. runAction() only skips re-queuing
+         * an action once `executed` is true -- without it, a later re-parse of
+         * the same message (e.g. re-rendering chat history) calls runAction()
+         * again for this action, which queues another #executeAction() that
+         * unconditionally flips status back to 'running', undoing the abort.
+         */
+        this.#updateAction(actionId, { status: 'aborted', executed: true });
       },
       abortSignal: abortController.signal,
     });
@@ -150,6 +158,16 @@ export class ActionRunner {
 
   async #executeAction(actionId: string, isStreaming: boolean = false) {
     const action = this.actions.get()[actionId];
+
+    /*
+     * This runs from a queued microtask (runAction() chains it onto
+     * #currentExecutionPromise), so it can execute *after* abort() already
+     * marked the action 'aborted'. Without this guard it always overwrites
+     * that with 'running', regardless of how much earlier the abort happened.
+     */
+    if (action.abortSignal.aborted) {
+      return;
+    }
 
     this.#updateAction(actionId, { status: 'running' });
 


### PR DESCRIPTION
## Summary

Three small, independent bug fixes found while debugging a real interrupted-generation scenario (an LLM response cut off mid-file). Each is reproducible on current `main` and verified against a live deployment.

### 1. `app/lib/persistence/useChatHistory.ts` — stale closure on first save

When a new chat's first `urlId` is generated (`storeMessageHistory`), it's assigned to a local `_urlId` and to React state via `setUrlId(urlId)`, but the `setMessages(...)` call that actually persists the chat still reads the *old* `urlId` closure variable, which is still `undefined` at that point. The chat gets saved with `urlId: undefined` and never becomes reachable from the sidebar again (history list filters on `item.urlId && item.description`), even though the chat and its messages are otherwise saved correctly. One-word fix: use `_urlId` (the value just computed a few lines above) instead of `urlId` in that call.

### 2. `app/lib/runtime/action-runner.ts` — abort() undone by an already-queued execution

Calling `action.abort()` sets `status: 'aborted'`, but `runAction()` had already chained a call onto `#currentExecutionPromise` before the abort happened. That queued `#executeAction()` runs on a later microtask and unconditionally does `this.#updateAction(actionId, { status: 'running' })` at its start, silently overwriting the abort. Fixed two ways: `abort()` now also sets `executed: true` (so `runAction()`'s existing `if (action.executed) return;` guard prevents any *future* re-queue), and `#executeAction()` now checks `action.abortSignal.aborted` before doing anything, so an *already-queued* execution can no longer clobber an abort that happened in between.

### 3. `app/components/chat/Artifact.tsx` — spinner never resolves for an interrupted file action

If a response gets cut off mid-file (token limit, dropped connection, client crash), the corresponding `<boltAction type="file">` never gets its closing tag, so it never receives the event that would flip it to `'complete'`. The action list then shows a spinner for that file forever, even after reload, even with no generation active — nothing is actually running, but the UI can't tell. Rather than trying to catch every code path that can leave an action in this state, this fixes it at render time: `ActionList` now reads the existing `streamingState` store, and a `'file'` action stuck at `pending`/`running` is shown as aborted once nothing is actually streaming. `'start'`/`'shell'` actions are intentionally excluded, since those can legitimately keep running well after the text stream ends (e.g. a real in-progress `npm install`).

## Testing

All three verified on a real fork deployment against a chat where generation was genuinely interrupted mid-file (frozen tab). Confirmed: (a) the affected chat becomes reachable from history again on new chats, (b) the abort no longer gets silently reverted, (c) the file action correctly shows as aborted instead of spinning forever, with no change in behavior for actions that complete normally or for shell/start actions that are still genuinely running.

## Scope

Deliberately minimal and independent from each other -- no unrelated refactors, no changes to files outside these three.
